### PR TITLE
ci: add PR-only GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate Prisma client
+        run: npx prisma generate
+
       - name: Type check
         run: npx tsc --noEmit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,50 +1,28 @@
 name: CI
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
-    branches: [main, develop]
+    branches:
+      - main
+      - dev
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Run linter
-        run: npm run lint
-
-      - name: Run type check
+      - name: Type check
         run: npx tsc --noEmit
 
-      - name: Run unit tests
+      - name: Run tests
         run: npm run test
-
-      - name: Build application
-        run: npm run build
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
-
-      - name: Run E2E tests
-        run: npm run e2e
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30


### PR DESCRIPTION
## Summary
- Rewrites `.github/workflows/ci.yml` — the old file targeted a non-existent `develop` branch and ran Playwright E2E
- New workflow triggers only on PRs to `main` or `dev`
- Job is named `ci` (required for branch protection status check)
- Steps: checkout → Node 20 → `npm ci` → `npx tsc --noEmit` → `npm run test`
- No Playwright, no caching, no build step

## Why
Fixes the branch mismatch noted in AI_NOTES.md (CI was watching `develop`, active branch is `dev`). Keeps PR checks fast — Vitest only, no E2E.

## Test plan
- [ ] PR opens and GitHub Actions run is triggered
- [ ] All 3 steps (install, typecheck, tests) pass green
- [ ] `ci` job name appears in branch protection status check dropdown after this runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)