### PR TITLE
sync: bring dev up to date with main + update AI docs

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -36,7 +36,8 @@ This file is the current handover source of truth. If another document conflicts
 Target: 5 operators onboarded, ~50 packages live. No code blockers for this gate — it is an operator acquisition and data-quality goal.
 
 **Pre-req before any operator onboarding:**
-- `/public/logo.svg` and `/public/text-logo.svg` still contain PilgrimCompare — fix first (Q1 scope)
+- `WordmarkLogo` component (`components/graphics/WordmarkLogo.tsx`) ✅ done — Nunito ExtraBold 800, `currentColor`, used in Header + Footer
+- `/public/logo.svg` and `/public/text-logo.svg` static files — verify brand strings are current (Q1 scope)
 
 ---
 
@@ -332,14 +333,14 @@ Mailboxes `support/privacy/dpo/complaints@pilgrimcompare.co.uk` → Cloudflare E
 |---|---|---|
 | Prompt 1 | MockDB removal + `FEATURE_USE_REAL_DB` fail-fast | ✅ Done |
 | Prompt 2 | RLS and grants audit — migrations 008 + 009 | ✅ Done |
-| Prompt 3 | Domain wiring + full PilgrimCompare → PilgrimCompare rebrand | ✅ Done |
+| Prompt 3 | Domain wiring + full KaabaTrip → PilgrimCompare rebrand | ✅ Done |
 | Prompt 4 | GitHub branch protection + CI workflow | ✅ Done |
 
 ### Quality pass queue — NEXT
 
 | Queue | Task | Pre-req |
 |---|---|---|
-| **Q1** ← next | PilgrimCompare sweep + banned-phrase audit + dynamic departure cities + logo SVGs | `docs/PILGRIMCOMPARE_LANGUAGE_AND_LEGAL_STANDARDS.md` committed |
+| **Q1** ← next | PilgrimCompare sweep + banned-phrase audit + dynamic departure cities | `docs/PILGRIMCOMPARE_LANGUAGE_AND_LEGAL_STANDARDS.md` committed |
 | Q2 | Legal pages `/terms` `/privacy` `/how-it-works` | Q1 done |
 | Q3 | IA/nav — header, footer, back buttons, breadcrumbs | Q1 done |
 | Q4 | Mobile polish 360/390/430px | Q3 done |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -7,7 +7,7 @@
 
 **Stack:** Next.js 15.5 (App Router, Server Components) · React 19 · TypeScript strict · Supabase (auth/Postgres/RLS/storage, `eu-west-2`) · Prisma · Tailwind · Zustand · Vitest + Playwright.
 
-**State (2026-06-10):** Branch `dev`. Tests 232/232 ✅. Build clean ✅. MockDB removed from production paths. RLS audit complete. Transactional email suite live. All domain redirects working — `pilgrimcompare.com` and `www.pilgrimcompare.com` both 301 to `pilgrimcompare.co.uk`. Supabase email confirmations ON.
+**State (2026-06-10):** Branch `dev` (1 commit behind `main` — pending structural sync PR). Tests 232/232 ✅. Build clean ✅. MockDB removed from production paths. RLS audit complete. Transactional email suite live. All domain redirects working — `pilgrimcompare.com` and `www.pilgrimcompare.com` both 301 to `pilgrimcompare.co.uk`. Supabase email confirmations ON. **WordmarkLogo** component live in Header + Footer (`components/graphics/WordmarkLogo.tsx`, Nunito ExtraBold 800, `currentColor`). PR #34 merged to `main`.
 
 **Remaining setup items:** None — all setup complete. Email mailboxes `support/privacy/dpo/complaints@pilgrimcompare.co.uk` live via Cloudflare Email Routing (→ Gmail). Upgrade to Google Workspace when onboarding real operators.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 > **Single rolling tracker.** Any AI/dev: read this for current state. Update it after work is **done + tested + verified** (see `CLAUDE.md` rule).
 > Detailed handover lives in `AI_NOTES.md`. Cold-start brief: `HANDOFF.md`. Business: `BUSINESS.md`.
 
-**Last verified:** 2026-06-10 (www redirect fix + infra verification) · **Branch:** `docs/session-4-notes` → `main` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
+**Last verified:** 2026-06-10 (wordmark rebrand + PR #34 dev→main merged) · **Branch:** `dev` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
 
 ---
 
@@ -100,7 +100,8 @@
 - A11y: WCAG 2.2 AA, ARIA, keyboard nav, 44px tap targets
 - Security: nonce-based CSP (replaced unsafe-inline), RLS migrations, rate limiting (Upstash)
 - RLS audit (2026-06-10): all 13 tables RLS-enabled; migration 008 fixed `evidence-files` + `operator-exports` storage buckets `{public}` → `{authenticated}` (critical); migration 009 added `WITH CHECK` to all 7 UPDATE policies (prevents ownership field mutation)
-- Rebrand + domain wiring (2026-06-10): brand `PilgrimCompare` → `PilgrimCompare`; domain `pilgrimcompare.co.uk` wired in all page metadata, JSON-LD, robots, sitemap; `NEXT_PUBLIC_SITE_URL=https://pilgrimcompare.co.uk` set in Vercel ✅; Cloudflare `.com` → `.co.uk` 301 redirect rule active ✅; `www.pilgrimcompare.com` CNAME (proxied) added → redirects to `pilgrimcompare.co.uk` ✅
+- Rebrand + domain wiring (2026-06-10): brand `KaabaTrip` → `PilgrimCompare`; domain `pilgrimcompare.co.uk` wired in all page metadata, JSON-LD, robots, sitemap; `NEXT_PUBLIC_SITE_URL=https://pilgrimcompare.co.uk` set in Vercel ✅; Cloudflare `.com` → `.co.uk` 301 redirect rule active ✅; `www.pilgrimcompare.com` CNAME (proxied) added → redirects to `pilgrimcompare.co.uk` ✅
+- **WordmarkLogo component (2026-06-10):** `components/graphics/WordmarkLogo.tsx` — inline SVG text wordmark, Nunito ExtraBold 800, `currentColor` fill (theme-flexible). Used in `Header` (desktop + mobile drawer) and `Footer`. Nunito loaded via `next/font/google` in `app/layout.tsx` (`--font-nunito`). Merged to `main` via PR #34.
 - `/settings` page: profile (editable name, email, avatar, role badge), security (password reset email), notification toggles (offer updates / booking updates / marketing), data export + account deletion (GDPR Art 20/17)
 - Mobile nav overhaul: icons, user card with avatar, "Get a Quote" as yellow CTA, active state left-border accent, danger-styled log out
 
@@ -110,18 +111,15 @@
 
 | Item | Status | Blocker |
 | --- | --- | --- |
-| Merge `dev` → `main` | PR #27 already merged | — |
+| Sync `main` → `dev` merge commit | PR needed (0 files changed, structural only) | Create PR `base:dev ← compare:main` on GitHub |
+| Q1 quality pass | Not started | `docs/PILGRIMCOMPARE_LANGUAGE_AND_LEGAL_STANDARDS.md` committed (founder task) |
 
 ---
 
 ## ▶️ Next actions (do in order)
 
-1. ✅ ~~Apply migration 004 to Supabase~~ — applied + verified 2026-06-08.
-2. ✅ ~~Open PR `dev` → `main`~~ — [PR #27](https://github.com/aliimrankhan86/kb-live/pull/27) open 2026-06-09.
-3. Review + merge PR #27 (run Playwright smoke 320px/1280px before merge).
-4. (then) groom backlog — see `docs/EXECUTION_QUEUE.md`.
-
-> **Queue status (2026-06-08):** EXECUTION_QUEUE Tasks 13/14/16 verified `[x]`; Task 17 `[~]` — gate green, only manual dev smoke + commit/push remain. No `[ ]` backlog left in the queue. Migration 004 applied → only Pending items are dev-login strip (pre-prod) + PR `dev`→`main`.
+1. Merge PR `main → dev` to bring `dev` in sync with `main` (1 commit, 0 files changed — the PR #34 merge commit).
+2. Start Q1 — PilgrimCompare language sweep + banned-phrase audit + dynamic departure cities. See `docs/PILGRIMCOMPARE_QUALITY_PROMPTS.md` → Q1.
 
 ---
 


### PR DESCRIPTION
## Summary

- Pulls in merge commit `ecfd5a6` (PR #34 dev→main) back into dev so both branches share identical history
- Updates `STATUS.md`, `HANDOFF.md`, `AI_NOTES.md` to reflect WordmarkLogo rebrand, correct branch state, and accurate next actions

## Changes

- `STATUS.md` — last verified header, WordmarkLogo entry in Done, Pending + Next actions rewritten
- `HANDOFF.md` — state line updated with WordmarkLogo, PR #34 merged, dev sync status
- `AI_NOTES.md` — Q1 row cleaned, Gate 3 pre-req updated, Prompt 3 label corrected (KaabaTrip → PilgrimCompare)

## Test plan

- [ ] Docs-only change — no code modified
- [ ] `npm run test` not required (no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)