### PR TITLE
chore: ignore editor swap/temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@
 .DS_Store
 *.pem
 
+# editor swap / temp files (Vim, etc.)
+*.swp
+*.swo
+*.swn
+*~
+
 # debug
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Summary
Ignore editor swap/temp files so they never get staged.

A stale Vim swap file — `lib/api/db/.adapter.ts.swp`, orphaned from a dead editor session (its owning process was gone) — surfaced as untracked because `.gitignore` had no swap pattern. The real source file `lib/api/db/adapter.ts` was untouched.

## Changes
- Deleted the stale `.swp` file (editor temp, not required).
- Added ignore patterns: `*.swp`, `*.swo`, `*.swn`, `*~`.

No source or behaviour change. Off `dev`, separate from the UX work in #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
