### PR TITLE
feat(q3): IA/nav pass — Packages/Compare nav, footer cities, breadcrumbs, sidebar back links

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -341,8 +341,8 @@ Mailboxes `support/privacy/dpo/complaints@pilgrimcompare.co.uk` → Cloudflare E
 |---|---|---|
 | ~~Q1~~ ✅ | PilgrimCompare sweep + banned-phrase audit + dynamic departure cities | Done 2026-06-12 — see §17 |
 | ~~Q2~~ ✅ | Legal pages `/terms` `/privacy` `/how-it-works` | Done 2026-06-12 — see §18 |
-| **Q3** ← next | IA/nav — header, footer, back buttons, breadcrumbs | Partial — footer + drawer done 2026-06-10 (see §13) |
-| Q4 | Mobile polish 360/390/430px | Q3 done |
+| ~~Q3~~ ✅ | IA/nav — header, footer, back buttons, breadcrumbs | Done 2026-06-12 — see §19 |
+| **Q4** ← next | Mobile polish 360/390/430px | Q3 done |
 | Q5 | SEO — metadata, JSON-LD, sitemap | Q1 done |
 | Q6 | Ranking transparency + Featured infrastructure | Revenue model confirmed |
 
@@ -641,5 +641,50 @@ The `CookieConsent` component still says "Analytics cookies help us understand h
 - Footer entity block reads from `LEGAL_ENTITY_BLOCK`: "PilgrimCompare is a trading name of Paramount Consultants Limited, registered in England and Wales (company no. 09679002). VAT no. GB 221 6154 46."
 - 12× `{/* LEGAL REVIEW */}` tags confirmed in `app/terms/page.tsx` — all in §8 liability section
 - 0 browser console errors
+
+---
+
+## 19. Q3 IA/Nav Pass — 2026-06-12
+
+**Branch:** `feat/q3-ia-nav` (off `dev`).
+
+### What shipped
+
+**`components/layout/Header.tsx`** — Primary nav restructured from `Umrah / Hajj / Get a Quote` to `Packages / Compare / How it works`. Compare → `/search/packages` (existing route, no new route needed). Guest secondary link renamed `For Partners` → `For Operators`. Three new path icons added to `ICONS` object (`packages`, `compare`, `howItWorks`).
+
+**`components/layout/Footer.tsx`** — Three targeted changes: (1) added `cities?: string[]` prop; (2) replaced brand tagline with verbatim "what we do" paragraph per §10.1 (comparison + enquiry service, not a travel agent, no payments); (3) dynamic "Departing from" block inside Platform section renders `<Link href="/umrah/{city.toLowerCase()}">` per city — only shown when `cities.length > 0`.
+
+**`app/layout.tsx`** — Made async. Fetches `Repository.getDistinctDepartureCities()` at layout level with try/catch (empty array fallback on DB failure). Passes result to `<Footer cities={departureCities} />`. No SSR penalty on first byte — query is cheap + cached.
+
+**`components/marketing/CityCorridor.tsx`** — Removed duplicate `<Header />` render (layout already provides it). Added optional `breadcrumbItems?: BreadcrumbItem[]` prop. Renders `<Breadcrumb>` inside `<article>` before the `<h1>` when provided.
+
+**Breadcrumbs added to:**
+- `app/umrah/london/page.tsx` — Home / Umrah / London
+- `app/umrah/birmingham/page.tsx` — Home / Umrah / Birmingham
+- `app/umrah/manchester/page.tsx` — Home / Umrah / Manchester
+- `app/umrah/ramadan/page.tsx` — Home / Umrah / Ramadan Umrah
+- `app/umrah/cost/page.tsx` — Home / Umrah / Cost guide
+- `app/requests/[id]/confirmation/page.tsx` — Home / My requests / Request / Confirmation
+
+**`components/operator/OperatorSidebar.tsx`** — "Back to PilgrimCompare" `<Link href="/">` added at bottom. 44px tap target, chevron-left icon, muted→normal hover colour, closes mobile drawer on click.
+
+**`components/admin/AdminSidebar.tsx`** — New `'use client'` component. Active nav highlighting via `usePathname()` (exact match + prefix match). aria-current="page" on active item. "Back to PilgrimCompare" link. Email displayed in footer.
+
+**`app/admin/layout.tsx`** — Replaced inline static nav HTML with `<AdminSidebar userEmail={user.email} />`.
+
+**`components/request/ComparisonTable.tsx`** — Fixed pre-existing unused variable lint warning (`(row, i)` → `(row)` on header column map).
+
+### 🛠️ Gotchas
+
+- **Turbopack + `npm run build` conflict**: Running `npm run build` while `npm run dev` (Turbopack) is up corrupts `.next/static/development/_buildManifest.js.tmp.*`, causing ISE on all pages. Fix: stop dev server, delete `.next/static/development/`, restart. Documented in §15.
+- **`<a>` lint error on internal links**: Next.js `@next/next/no-html-link-for-pages` rejects `<a href="/">` for internal routes. Both sidebar back links needed `<Link>` from `next/link`.
+- **CityCorridor double-header**: Component previously rendered its own `<Header />` — this caused two headers on all corridor pages. Removed in this pass.
+
+### Validation
+- `npx tsc --noEmit` pass
+- `npm run test` 238/238 (no new tests; 3 existing legal tests already in count)
+- `npm run build` 0 errors
+- Desktop: header `Packages / Compare / How it works` confirmed; footer "what we do" paragraph + "DEPARTING FROM London" confirmed
+- Mobile 390px: hamburger drawer shows `Packages / Compare / How it works / For Operators`; `/umrah/london` shows `← Umrah` compact back affordance; breadcrumb trail on desktop
 
 **Next:** Q3 — IA/nav pass (header, footer, back buttons, breadcrumbs). Test count: 238/238.

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,13 +1,7 @@
 import type { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
-import Link from 'next/link';
 import { getSessionUser } from '@/lib/auth/session';
-
-const adminNavItems = [
-  { label: 'Bank Changes', href: '/admin/bank-changes' },
-  { label: 'Complaints', href: '/admin/complaints' },
-  { label: 'Reconciliation', href: '/admin/reconciliation' },
-];
+import { AdminSidebar } from '@/components/admin/AdminSidebar';
 
 interface AdminLayoutProps {
   children: ReactNode;
@@ -27,33 +21,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
   return (
     <div className="min-h-screen bg-[#0B0B0B] text-[#FFFFFF]">
       <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-4 px-4 py-4 md:flex-row md:gap-6 md:px-6 md:py-6">
-        {/* Sidebar */}
-        <aside
-          className="w-full md:w-[260px] md:self-start md:rounded-xl md:border md:border-[rgba(255,255,255,0.1)] md:bg-[#111111] md:p-4"
-          aria-label="Admin navigation"
-        >
-          <div className="mb-6">
-            <p className="text-xs uppercase tracking-wide text-[rgba(255,255,255,0.64)]">PilgrimCompare</p>
-            <h2 className="text-xl font-semibold text-[#FFFFFF]">Admin</h2>
-          </div>
-
-          <nav className="space-y-2" aria-label="Admin sections">
-            {adminNavItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="flex min-h-11 items-center rounded-md border border-[rgba(255,255,255,0.08)] bg-transparent px-3 py-2 text-sm font-medium text-[rgba(255,255,255,0.78)] transition-colors hover:border-[rgba(255,255,255,0.2)] hover:text-[#FFFFFF] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FFD31D]"
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-
-          <div className="mt-6 border-t border-[rgba(255,255,255,0.1)] pt-4">
-            <p className="text-sm font-medium text-[#FFFFFF]">Admin</p>
-            <p className="mt-2 text-xs text-[rgba(255,255,255,0.5)]">{user.email}</p>
-          </div>
-        </aside>
+        <AdminSidebar userEmail={user.email} />
 
         {/* Main content */}
         <main className="min-w-0 flex-1 rounded-xl border border-[rgba(255,255,255,0.1)] bg-[#111111] p-4 md:p-6">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { CookieConsent } from "@/components/compliance/CookieConsent";
 import { JsonLdScript } from "@/lib/seo/json-ld";
+import { Repository } from "@/lib/api/repository";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -46,11 +47,18 @@ const travelAgencyJsonLd = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  let departureCities: string[] = [];
+  try {
+    departureCities = await Repository.getDistinctDepartureCities();
+  } catch {
+    // DB unavailable — footer renders without city links
+  }
+
   return (
     <html lang="en-GB" className={`${exo2Font.variable} ${inter.variable} ${nunito.variable}`} suppressHydrationWarning>
       <body className="antialiased min-h-screen flex flex-col">
@@ -65,7 +73,7 @@ export default function RootLayout({
         <main id="main-content" className="flex-1">
           {children}
         </main>
-        <Footer />
+        <Footer cities={departureCities} />
         <CookieConsent />
       </body>
     </html>

--- a/app/requests/[id]/confirmation/page.tsx
+++ b/app/requests/[id]/confirmation/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { Repository } from '@/lib/api/repository';
+import { Breadcrumb } from '@/components/ui/Breadcrumb';
 
 export default async function BookingConfirmationPage({
   params,
@@ -24,6 +25,14 @@ export default async function BookingConfirmationPage({
       className="min-h-screen bg-[var(--background)] px-4 py-12"
     >
       <div className="mx-auto max-w-xl space-y-8">
+        <Breadcrumb
+          items={[
+            { label: 'Home', href: '/' },
+            { label: 'My requests', href: '/requests' },
+            { label: 'Request', href: `/requests/${id}` },
+            { label: 'Confirmation' },
+          ]}
+        />
         {/* Reference code */}
         <div className="rounded-xl border border-[var(--yellow)] bg-[rgba(255,211,29,0.06)] px-6 py-8 text-center">
           <p className="text-sm font-medium uppercase tracking-wide text-[var(--yellow)]">

--- a/app/umrah/birmingham/page.tsx
+++ b/app/umrah/birmingham/page.tsx
@@ -74,6 +74,11 @@ export default async function BirminghamUmrahPage() {
         intro="Find Umrah packages departing from Birmingham Airport (BHX). Compare verified UK operators side by side, filter by hotel rating and distance to Haram, and request a quote in minutes."
         queryParams="?type=umrah&departureCity=Birmingham"
         faqs={faqs}
+        breadcrumbItems={[
+          { label: 'Home', href: '/' },
+          { label: 'Umrah', href: '/umrah' },
+          { label: 'Birmingham' },
+        ]}
       />
     </>
   )

--- a/app/umrah/cost/page.tsx
+++ b/app/umrah/cost/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { JsonLdScript, breadcrumbJsonLd, faqPageJsonLd, graphJsonLd, webPageJsonLd } from '@/lib/seo/json-ld'
 import { Repository } from '@/lib/api/repository'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
 
 export const metadata: Metadata = {
   title: 'How Much Does an Umrah Package Cost from the UK? 2026–2027 Guide',
@@ -82,6 +83,14 @@ export default async function UmrahCostPage() {
       <JsonLdScript data={pageJsonLd} />
       <main className="min-h-screen bg-[var(--background)] px-4 py-12 md:py-20">
         <article className="mx-auto max-w-3xl">
+          <Breadcrumb
+            className="mb-6"
+            items={[
+              { label: 'Home', href: '/' },
+              { label: 'Umrah', href: '/umrah' },
+              { label: 'Cost guide' },
+            ]}
+          />
           <h1 className="text-3xl md:text-4xl font-bold text-[var(--text)] mb-6">
             How Much Does an Umrah Package Cost from the UK?
           </h1>

--- a/app/umrah/london/page.tsx
+++ b/app/umrah/london/page.tsx
@@ -74,6 +74,11 @@ export default async function LondonUmrahPage() {
         intro="Find Umrah packages departing from London Heathrow, Gatwick, and Stansted. Compare verified UK operators side by side, filter by hotel rating and distance to Haram, and request a quote in minutes."
         queryParams="?type=umrah&departureCity=London"
         faqs={faqs}
+        breadcrumbItems={[
+          { label: 'Home', href: '/' },
+          { label: 'Umrah', href: '/umrah' },
+          { label: 'London' },
+        ]}
       />
     </>
   )

--- a/app/umrah/manchester/page.tsx
+++ b/app/umrah/manchester/page.tsx
@@ -74,6 +74,11 @@ export default async function ManchesterUmrahPage() {
         intro="Find Umrah packages departing from Manchester Airport (MAN). Compare verified UK operators side by side, filter by hotel rating and distance to Haram, and request a quote in minutes."
         queryParams="?type=umrah&departureCity=Manchester"
         faqs={faqs}
+        breadcrumbItems={[
+          { label: 'Home', href: '/' },
+          { label: 'Umrah', href: '/umrah' },
+          { label: 'Manchester' },
+        ]}
       />
     </>
   )

--- a/app/umrah/ramadan/page.tsx
+++ b/app/umrah/ramadan/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { JsonLdScript, breadcrumbJsonLd, faqPageJsonLd, graphJsonLd, webPageJsonLd } from '@/lib/seo/json-ld'
 import { Repository } from '@/lib/api/repository'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
 
 export const metadata: Metadata = {
   title: 'Ramadan Umrah Packages 2027 from the UK',
@@ -64,6 +65,14 @@ export default async function RamadanUmrahPage() {
       <JsonLdScript data={pageJsonLd} />
       <main className="min-h-screen bg-[var(--background)] px-4 py-12 md:py-20">
         <article className="mx-auto max-w-3xl">
+          <Breadcrumb
+            className="mb-6"
+            items={[
+              { label: 'Home', href: '/' },
+              { label: 'Umrah', href: '/umrah' },
+              { label: 'Ramadan Umrah' },
+            ]}
+          />
           <h1 className="text-3xl md:text-4xl font-bold text-[var(--text)] mb-6">
             Ramadan Umrah Packages from the UK 2027
           </h1>

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const adminNavItems = [
+  { label: 'Bank Changes', href: '/admin/bank-changes' },
+  { label: 'Complaints', href: '/admin/complaints' },
+  { label: 'Reconciliation', href: '/admin/reconciliation' },
+];
+
+const navItemClasses =
+  'flex min-h-11 items-center rounded-md border px-3 py-2 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FFD31D]';
+
+interface AdminSidebarProps {
+  userEmail: string;
+}
+
+export function AdminSidebar({ userEmail }: AdminSidebarProps) {
+  const pathname = usePathname();
+
+  return (
+    <aside
+      className="w-full md:w-[260px] md:self-start md:rounded-xl md:border md:border-[rgba(255,255,255,0.1)] md:bg-[#111111] md:p-4"
+      aria-label="Admin navigation"
+    >
+      <div className="mb-6">
+        <p className="text-xs uppercase tracking-wide text-[rgba(255,255,255,0.64)]">PilgrimCompare</p>
+        <h2 className="text-xl font-semibold text-[#FFFFFF]">Admin</h2>
+      </div>
+
+      <nav className="space-y-2" aria-label="Admin sections">
+        {adminNavItems.map((item) => {
+          const active = pathname === item.href || pathname.startsWith(item.href + '/');
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`${navItemClasses} ${
+                active
+                  ? 'border-[#FFD31D] bg-[rgba(255,211,29,0.12)] text-[#FFFFFF]'
+                  : 'border-[rgba(255,255,255,0.08)] bg-transparent text-[rgba(255,255,255,0.78)] hover:border-[rgba(255,255,255,0.2)] hover:text-[#FFFFFF]'
+              }`}
+              aria-current={active ? 'page' : undefined}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <div className="mt-6 border-t border-[rgba(255,255,255,0.1)] pt-4">
+        <p className="text-sm font-medium text-[#FFFFFF]">Admin</p>
+        <p className="mt-2 text-xs text-[rgba(255,255,255,0.5)]">{userEmail}</p>
+      </div>
+
+      <div className="mt-4 border-t border-[rgba(255,255,255,0.1)] pt-4">
+        <a
+          href="/"
+          className="flex min-h-[44px] items-center gap-2 rounded-md px-3 py-2 text-xs text-[rgba(255,255,255,0.5)] hover:text-[rgba(255,255,255,0.85)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FFD31D]"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M15 18l-6-6 6-6" />
+          </svg>
+          Back to PilgrimCompare
+        </a>
+      </div>
+    </aside>
+  );
+}

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -55,7 +55,7 @@ export function AdminSidebar({ userEmail }: AdminSidebarProps) {
       </div>
 
       <div className="mt-4 border-t border-[rgba(255,255,255,0.1)] pt-4">
-        <a
+        <Link
           href="/"
           className="flex min-h-[44px] items-center gap-2 rounded-md px-3 py-2 text-xs text-[rgba(255,255,255,0.5)] hover:text-[rgba(255,255,255,0.85)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FFD31D]"
         >
@@ -63,7 +63,7 @@ export function AdminSidebar({ userEmail }: AdminSidebarProps) {
             <path d="M15 18l-6-6 6-6" />
           </svg>
           Back to PilgrimCompare
-        </a>
+        </Link>
       </div>
     </aside>
   );

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -13,9 +13,10 @@ const LEGAL_LINKS = [
 ];
 
 const PLATFORM_LINKS = [
+  { href: '/packages', label: 'Browse Packages' },
+  { href: '/search/packages', label: 'Compare Packages' },
   { href: '/quote', label: 'Get a Quote' },
-  { href: '/search/packages', label: 'Search Packages' },
-  { href: '/partner', label: 'For Partners' },
+  { href: '/partner', label: 'For Operators' },
 ];
 
 const linkClass =
@@ -96,7 +97,7 @@ function Section({
   );
 }
 
-export function Footer() {
+export function Footer({ cities = [] }: { cities?: string[] }) {
   const currentYear = new Date().getFullYear();
   const isDesktop = useIsDesktop();
 
@@ -113,8 +114,12 @@ export function Footer() {
             <Logo size={26} />
             <WordmarkLogo height={24} style={{ color: 'var(--wordmark-color, var(--yellow, #FFD31D))' }} />
           </Link>
-          <p className="text-xs leading-relaxed text-[var(--textMuted)] md:max-w-xs">
-            Compare Umrah and Hajj packages from verified UK travel operators.
+          <p className="text-xs leading-relaxed text-[var(--textMuted)] md:max-w-sm">
+            PilgrimCompare is a UK comparison and enquiry service for Umrah travel packages. We list
+            packages from independent, verified UK travel operators so you can compare them side by
+            side and send enquiries directly. We are not a travel agent, tour operator, or organiser.
+            We do not sell travel, take bookings, or handle payments. Your booking, contract, and
+            payment are always with the operator you choose.
           </p>
         </div>
 
@@ -164,6 +169,25 @@ export function Footer() {
                 </li>
               ))}
             </ul>
+            {cities.length > 0 && (
+              <div className="mt-4">
+                <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--textMuted)]">
+                  Departing from
+                </p>
+                <ul className="space-y-2 text-xs">
+                  {cities.map(city => (
+                    <li key={city}>
+                      <Link
+                        href={`/umrah/${city.toLowerCase()}`}
+                        className={linkClass}
+                      >
+                        {city}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </Section>
         </div>
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -49,6 +49,9 @@ const ICONS = {
     d2: 'M15 12a3 3 0 11-6 0 3 3 0 016 0z',
   },
   logout: 'M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1',
+  packages: 'M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4',
+  compare: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
+  howItWorks: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
 };
 
 export function Header({ className = '' }: { className?: string }) {
@@ -193,13 +196,13 @@ export function Header({ className = '' }: { className?: string }) {
 
 
   const navLinks = [
-    { href: '/umrah', label: 'Umrah', testId: 'nav-umrah', icon: ICONS.umrah },
-    { href: '/hajj', label: 'Hajj', testId: 'nav-hajj', icon: ICONS.hajj },
-    { href: '/quote', label: 'Get a Quote', testId: 'nav-quote', icon: ICONS.quote },
+    { href: '/packages', label: 'Packages', testId: 'nav-packages', icon: ICONS.packages },
+    { href: '/search/packages', label: 'Compare', testId: 'nav-compare', icon: ICONS.compare },
+    { href: '/how-it-works', label: 'How it works', testId: 'nav-how-it-works', icon: ICONS.howItWorks },
   ];
 
   const guestLinks = [
-    { href: '/partner', label: 'For Partners', testId: 'nav-partners', icon: ICONS.partners },
+    { href: '/partner', label: 'For Operators', testId: 'nav-operators', icon: ICONS.partners },
   ];
 
   const customerLinks = [

--- a/components/marketing/CityCorridor.tsx
+++ b/components/marketing/CityCorridor.tsx
@@ -1,5 +1,6 @@
-import { Header } from '@/components/layout/Header'
 import Link from 'next/link'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
+import type { BreadcrumbItem } from '@/components/ui/Breadcrumb'
 
 interface FAQ {
   question: string
@@ -12,85 +13,87 @@ interface CityCorridorProps {
   intro: string
   queryParams: string
   faqs?: FAQ[]
+  breadcrumbItems?: BreadcrumbItem[]
 }
 
-export function CityCorridor({ city, h1, intro, queryParams, faqs }: CityCorridorProps) {
+export function CityCorridor({ city, h1, intro, queryParams, faqs, breadcrumbItems }: CityCorridorProps) {
   return (
-    <>
-      <Header />
-      <main className="min-h-screen bg-[var(--background)] px-4 py-12 md:py-20">
-        <article className="mx-auto max-w-3xl">
-          <h1 className="text-3xl md:text-4xl font-bold text-[var(--text)] mb-6">{h1}</h1>
+    <main className="min-h-screen bg-[var(--background)] px-4 py-12 md:py-20">
+      <article className="mx-auto max-w-3xl">
+        {breadcrumbItems && breadcrumbItems.length > 0 && (
+          <Breadcrumb items={breadcrumbItems} className="mb-6" />
+        )}
 
-          <p className="text-lg text-[var(--textMuted)] leading-relaxed mb-8">{intro}</p>
+        <h1 className="text-3xl md:text-4xl font-bold text-[var(--text)] mb-6">{h1}</h1>
 
-          <section className="rounded-xl border border-[var(--border)] bg-[var(--surfaceDark)] p-6 md:p-8 mb-8">
-            <h2 className="text-xl font-semibold text-[var(--text)] mb-4">What to expect</h2>
-            <ul className="space-y-3 text-[var(--textMuted)]">
-              <li className="flex items-start gap-2">
-                <span aria-hidden="true" className="text-[var(--yellow)] font-bold mt-0.5">✓</span>
-                <span>Verified UK operators with ATOL or ABTA protection</span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span aria-hidden="true" className="text-[var(--yellow)] font-bold mt-0.5">✓</span>
-                <span>Compare packages side by side — up to 3 at a time</span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span aria-hidden="true" className="text-[var(--yellow)] font-bold mt-0.5">✓</span>
-                <span>Hotels near Haram in Makkah and Madinah, flights, transfers, and visa support</span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span aria-hidden="true" className="text-[var(--yellow)] font-bold mt-0.5">✓</span>
-                <span>Request a quote or book directly with the operator — PilgrimCompare does not hold your money</span>
-              </li>
-            </ul>
+        <p className="text-lg text-[var(--textMuted)] leading-relaxed mb-8">{intro}</p>
+
+        <section className="rounded-xl border border-[var(--border)] bg-[var(--surfaceDark)] p-6 md:p-8 mb-8">
+          <h2 className="text-xl font-semibold text-[var(--text)] mb-4">What to expect</h2>
+          <ul className="space-y-3 text-[var(--textMuted)]">
+            <li className="flex items-start gap-2">
+              <span aria-hidden="true" className="text-[var(--yellow)] font-bold mt-0.5">✓</span>
+              <span>Verified UK operators with ATOL or ABTA protection</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span aria-hidden="true" className="text-[var(--yellow)] font-bold mt-0.5">✓</span>
+              <span>Compare packages side by side — up to 3 at a time</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span aria-hidden="true" className="text-[var(--yellow)] font-bold mt-0.5">✓</span>
+              <span>Hotels near Haram in Makkah and Madinah, flights, transfers, and visa support</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span aria-hidden="true" className="text-[var(--yellow)] font-bold mt-0.5">✓</span>
+              <span>Request a quote or book directly with the operator — PilgrimCompare does not hold your money</span>
+            </li>
+          </ul>
+        </section>
+
+        <div className="flex flex-col sm:flex-row gap-4 mb-6">
+          <Link
+            href={`/search/packages${queryParams}`}
+            className="inline-flex items-center justify-center rounded-lg bg-[var(--yellow)] px-6 py-3 text-base font-semibold text-[var(--bg)] hover:opacity-90 transition-opacity"
+            data-testid={`corridor-cta-${city.toLowerCase()}`}
+          >
+            Browse Umrah packages from {city}
+          </Link>
+          <Link
+            href="/quote"
+            className="inline-flex items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--surfaceDark)] px-6 py-3 text-base font-medium text-[var(--text)] hover:border-[var(--yellow)]/40 transition-colors"
+          >
+            Request a custom quote
+          </Link>
+        </div>
+
+        <p className="text-sm text-[var(--textMuted)] mb-10">
+          Packages and availability are set by individual operators. Prices and inclusions vary.
+          Always confirm details directly with your chosen operator.
+        </p>
+
+        {faqs && faqs.length > 0 && (
+          <section className="mt-8">
+            <h2 className="text-lg font-semibold text-[var(--text)] mb-4">
+              Frequently asked questions
+            </h2>
+            <div className="space-y-3">
+              {faqs.map((faq, i) => (
+                <details
+                  key={i}
+                  className="rounded-lg border border-[var(--border)] bg-[var(--surfaceDark)] px-4 py-3"
+                >
+                  <summary className="cursor-pointer text-sm font-medium text-[var(--text)]">
+                    {faq.question}
+                  </summary>
+                  <p className="mt-2 text-sm text-[var(--textMuted)] leading-relaxed">
+                    {faq.answer}
+                  </p>
+                </details>
+              ))}
+            </div>
           </section>
-
-          <div className="flex flex-col sm:flex-row gap-4 mb-6">
-            <Link
-              href={`/search/packages${queryParams}`}
-              className="inline-flex items-center justify-center rounded-lg bg-[var(--yellow)] px-6 py-3 text-base font-semibold text-[var(--bg)] hover:opacity-90 transition-opacity"
-              data-testid={`corridor-cta-${city.toLowerCase()}`}
-            >
-              Browse Umrah packages from {city}
-            </Link>
-            <Link
-              href="/quote"
-              className="inline-flex items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--surfaceDark)] px-6 py-3 text-base font-medium text-[var(--text)] hover:border-[var(--yellow)]/40 transition-colors"
-            >
-              Request a custom quote
-            </Link>
-          </div>
-
-          <p className="text-sm text-[var(--textMuted)] mb-10">
-            Packages and availability are set by individual operators. Prices and inclusions vary.
-            Always confirm details directly with your chosen operator.
-          </p>
-
-          {faqs && faqs.length > 0 && (
-            <section className="mt-8">
-              <h2 className="text-lg font-semibold text-[var(--text)] mb-4">
-                Frequently asked questions
-              </h2>
-              <div className="space-y-3">
-                {faqs.map((faq, i) => (
-                  <details
-                    key={i}
-                    className="rounded-lg border border-[var(--border)] bg-[var(--surfaceDark)] px-4 py-3"
-                  >
-                    <summary className="cursor-pointer text-sm font-medium text-[var(--text)]">
-                      {faq.question}
-                    </summary>
-                    <p className="mt-2 text-sm text-[var(--textMuted)] leading-relaxed">
-                      {faq.answer}
-                    </p>
-                  </details>
-                ))}
-              </div>
-            </section>
-          )}
-        </article>
-      </main>
-    </>
+        )}
+      </article>
+    </main>
   )
 }

--- a/components/operator/OperatorSidebar.tsx
+++ b/components/operator/OperatorSidebar.tsx
@@ -111,6 +111,19 @@ export function OperatorSidebar({ operatorName, verificationStatus, userRole, us
           <p className={`mt-1 text-xs ${statusBadge.color}`}>{statusBadge.text}</p>
           <p className="mt-2 text-xs text-[rgba(255,255,255,0.5)]">{userName}</p>
         </div>
+
+        <div className="mt-4 border-t border-[rgba(255,255,255,0.1)] pt-4">
+          <a
+            href="/"
+            className="flex min-h-[44px] items-center gap-2 rounded-md px-3 py-2 text-xs text-[rgba(255,255,255,0.5)] hover:text-[rgba(255,255,255,0.85)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FFD31D]"
+            onClick={() => setMobileOpen(false)}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M15 18l-6-6 6-6" />
+            </svg>
+            Back to PilgrimCompare
+          </a>
+        </div>
       </aside>
     </>
   );

--- a/components/operator/OperatorSidebar.tsx
+++ b/components/operator/OperatorSidebar.tsx
@@ -113,7 +113,7 @@ export function OperatorSidebar({ operatorName, verificationStatus, userRole, us
         </div>
 
         <div className="mt-4 border-t border-[rgba(255,255,255,0.1)] pt-4">
-          <a
+          <Link
             href="/"
             className="flex min-h-[44px] items-center gap-2 rounded-md px-3 py-2 text-xs text-[rgba(255,255,255,0.5)] hover:text-[rgba(255,255,255,0.85)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FFD31D]"
             onClick={() => setMobileOpen(false)}
@@ -122,7 +122,7 @@ export function OperatorSidebar({ operatorName, verificationStatus, userRole, us
               <path d="M15 18l-6-6 6-6" />
             </svg>
             Back to PilgrimCompare
-          </a>
+          </Link>
         </div>
       </aside>
     </>

--- a/components/request/ComparisonTable.tsx
+++ b/components/request/ComparisonTable.tsx
@@ -133,7 +133,7 @@ export function ComparisonTable({ offers = [], rows }: ComparisonTableProps) {
             <th scope="col" className="bg-[var(--surfaceDark)] border-b border-[var(--borderSubtle)]">
               <span className="sr-only">Feature</span>
             </th>
-            {comparisonRows.map((row, i) => {
+            {comparisonRows.map((row) => {
               const headerLabel =
                 row.operatorName && row.operatorName !== 'Not provided'
                   ? row.operatorName

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -6,9 +6,9 @@
 
 ## Branch & goal
 
-- **Branch:** `feat/q1-brand-legal-cleanup` (off `dev`) → PR → `dev` → `main`
-- **Goal:** Q2 complete — legal pages live. Next: Q3 IA/nav pass.
-- **Current source-of-truth note:** Q2 verified 2026-06-12. Full detail in `AI_NOTES.md` §18.
+- **Branch:** `feat/q3-ia-nav` (off `dev`) → PR → `dev` → `main`
+- **Goal:** Q3 complete — IA/nav pass. Next: Q4 mobile polish.
+- **Current source-of-truth note:** Q3 verified 2026-06-12. Full detail in `AI_NOTES.md` §19.
 - **Canonical handover:** `AI_NOTES.md` is the single source of truth for verified status, implementation posture, and pending areas.
 
 ## What works (verified)
@@ -17,6 +17,20 @@
 - **Build**: `npm run build` passes with 0 errors — verified 2026-06-12.
 - **TypeScript**: `npx tsc --noEmit` passes — verified 2026-06-12.
 - **Architecture decision**: Supabase + Prisma + Upstash Redis is the correct target/production architecture. MockDB is not the production architecture, but production-facing MockDB imports remain and are now documented as launch blockers in `AI_NOTES.md` §0.
+
+## Changes made in this session (2026-06-12 — Q3 IA/Nav Pass)
+
+| Task | What | Files |
+| ---- | ---- | ----- |
+| STEP1 Primary nav | Replaced `Umrah / Hajj / Get a Quote` with `Packages / Compare / How it works`. Compare → `/search/packages`. For Partners → For Operators. New path icons. | `components/layout/Header.tsx` |
+| STEP2 Footer | Added `cities` prop; verbatim "what we do" paragraph; dynamic "Departing from" city links in Platform section. | `components/layout/Footer.tsx` |
+| STEP3 Layout wiring | Root layout async; fetches `Repository.getDistinctDepartureCities()` with try/catch; passes to Footer. | `app/layout.tsx` |
+| STEP4 Breadcrumbs | Breadcrumb added to Ramadan, Cost guide pages. CityCorridor gets optional `breadcrumbItems` prop + breadcrumb before h1; duplicate `<Header />` removed. Corridor pages (London, Birmingham, Manchester) pass breadcrumb items. | `app/umrah/ramadan/page.tsx`, `app/umrah/cost/page.tsx`, `components/marketing/CityCorridor.tsx`, `app/umrah/london/page.tsx`, `app/umrah/birmingham/page.tsx`, `app/umrah/manchester/page.tsx` |
+| STEP5 Confirmation breadcrumb | Breadcrumb at top of booking confirmation page. | `app/requests/[id]/confirmation/page.tsx` |
+| STEP6 Sidebar back links | OperatorSidebar: "Back to PilgrimCompare" link. AdminSidebar: new component with active highlighting + back link. Admin layout wired to AdminSidebar. | `components/operator/OperatorSidebar.tsx`, `components/admin/AdminSidebar.tsx`, `app/admin/layout.tsx` |
+| FIX Unused var | Pre-existing lint warning in ComparisonTable removed. | `components/request/ComparisonTable.tsx` |
+
+**Verification:** `npx tsc --noEmit` pass · `npm run test` 238/238 · `npm run build` 0 errors · desktop nav/footer confirmed in preview · mobile drawer confirmed at 390px · breadcrumbs visible on corridor + confirmation pages.
 
 ## Changes made in this session (2026-06-12 — Q2 Legal Pages)
 


### PR DESCRIPTION
## Summary

- **Primary nav** restructured: `Umrah / Hajj / Get a Quote` → `Packages / Compare / How it works`; Compare points to existing `/search/packages`; For Partners renamed For Operators
- **Footer** — verbatim "what we do" paragraph (comparison + enquiry service, not a travel agent); dynamic "Departing from" city links sourced live from DB via root layout
- **Breadcrumbs** — added to Umrah corridor pages (London, Birmingham, Manchester, Ramadan, Cost guide) and booking confirmation page; CityCorridor component refactored to accept `breadcrumbItems` prop and stop rendering its own `<Header />`
- **Sidebar back links** — OperatorSidebar and new AdminSidebar both have "Back to PilgrimCompare" link; AdminSidebar extracted from inline layout HTML with active highlighting via `usePathname()`

## Commits

- `feat(q3): update primary nav — Packages / Compare / How it works; rename For Partners → For Operators`
- `feat(q3): footer — verbatim 'what we do' paragraph, dynamic departure cities, operator terminology`
- `feat(q3): breadcrumbs on corridor + confirmation pages; remove duplicate Header from CityCorridor`
- `feat(q3): dashboard shells — back-to-site link in operator sidebar; AdminSidebar with active highlighting + back link`
- `fix(q3): use Link for back-to-site nav; fix pre-existing unused var in ComparisonTable`
- `chore(q3): update AI_NOTES §19 and NOW.md — Q3 IA/nav pass complete`

## Test plan

- [ ] `npm run test` — 238/238 pass
- [ ] `npm run build` — 0 errors
- [ ] `npx tsc --noEmit` — pass
- [ ] Desktop: header shows Packages / Compare / How it works; Compare links to `/search/packages`
- [ ] Desktop: footer shows "what we do" paragraph and departure city links
- [ ] Mobile 390px: hamburger drawer shows all 4 nav items; For Operators present
- [ ] `/umrah/london` (and birmingham/manchester): breadcrumb trail visible on desktop, `← Umrah` on mobile
- [ ] `/umrah/ramadan` and `/umrah/cost`: breadcrumb present
- [ ] `/requests/[id]/confirmation`: breadcrumb present
- [ ] `/operator/dashboard`: "Back to PilgrimCompare" link visible in sidebar
- [ ] `/admin/bank-changes`: AdminSidebar renders with active highlight; "Back to PilgrimCompare" link visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)