### PR TITLE
feat(q6): ranking transparency + Featured infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,40 @@
+# ─── PilgrimCompare environment variables ────────────────────────────────────
+#
+# Copy this file to .env.local for local development.
+# Production values are set in the Vercel dashboard — never commit real secrets.
+
+# ─── Database ─────────────────────────────────────────────────────────────────
+# Supabase Postgres connection string (pgBouncer pooler, port 6543)
+DATABASE_URL="postgresql://postgres.[ref]:[password]@aws-0-eu-west-1.pooler.supabase.com:6543/postgres?pgbouncer=true"
+
+# ─── Supabase ─────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_SUPABASE_URL="https://[ref].supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="eyJ..."
+SUPABASE_SERVICE_ROLE_KEY="eyJ..."
+
+# ─── Site URL ─────────────────────────────────────────────────────────────────
+# Production: https://pilgrimcompare.co.uk
+# Local dev: http://localhost:3000
+NEXT_PUBLIC_SITE_URL="http://localhost:3000"
+
+# ─── Email ────────────────────────────────────────────────────────────────────
+RESEND_API_KEY="re_..."
+
+# ─── Rate limiting ────────────────────────────────────────────────────────────
+UPSTASH_REDIS_REST_URL="https://..."
+UPSTASH_REDIS_REST_TOKEN="..."
+
+# ─── Feature flags ────────────────────────────────────────────────────────────
+
+# Use the real Postgres database instead of MockDB.
+# MUST be "true" in all non-test environments.
+# Never set in CI — prisma generate runs schema-only there.
+FEATURE_USE_REAL_DB=true
+
+# Activate Featured package slots in the list UI (Phase 2 monetisation).
+# Default: false. Set to true only when:
+#   1. At least one package has is_featured=TRUE in the database.
+#   2. Phase-2 Featured placement terms are agreed with that operator.
+#   3. The "Featured" label and placement disclosure are live.
+# NEVER read client-side — evaluate on server, pass as featuredSlotsEnabled prop.
+FEATURE_FEATURED_SLOTS=false

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -341,7 +341,7 @@ Mailboxes `support/privacy/dpo/complaints@pilgrimcompare.co.uk` → Cloudflare E
 | ~~Q3~~ ✅ | IA/nav — header, footer, back buttons, breadcrumbs | Done 2026-06-12 — see §19 |
 | ~~Q4~~ ✅ | Mobile polish 360/390/430px | Done 2026-06-12 — see §20 |
 | ~~Q5~~ ✅ | SEO — metadata, JSON-LD, sitemap, banned-phrase CI | Done 2026-06-12 — see §21 |
-| **Q6** ← next | Ranking transparency + Featured infrastructure | Revenue model confirmed |
+| ~~Q6~~ ✅ | Ranking transparency + Featured infrastructure | Done 2026-06-12 — see §22 |
 
 ---
 
@@ -803,4 +803,62 @@ Full SEO audit and remediation for all public routes: metadata, JSON-LD structur
 
 - `npx tsc --noEmit` pass
 - `npm run test` 1,425/1,425 (21 files)
+- `npm run build` 0 errors
+
+---
+
+## 22. Q6 Ranking Transparency + Featured Infrastructure — 2026-06-12
+
+### What changed
+
+**TASK 1 — Server-side neutral sort (`lib/ranking.ts`, `lib/api/repository.ts`)**
+- New `lib/ranking.ts`: `scorePackage(pkg, responseRate?)` and `sortByScore(packages[])`.
+- Score = 45% data completeness (16 optional fields) + 35% price recency (full ≤7 days, zero ≥90 days) + 20% operator response rate (neutral 0.5 until real data).
+- `isFeatured` has zero weight — never affects neutral score.
+- `Repository.listPackages()` now calls `sortByScore()` before returning; all pages receive pre-sorted packages server-side.
+
+**TASK 2 — Neutral sort disclosure (`components/search/PackageList.tsx`, `components/packages/PackagesBrowse.tsx`)**
+- `NEUTRAL_SORT_DISCLOSURE` from `lib/content-rules` rendered near every sort control, linked to `/how-we-rank`.
+- `data-testid="sort-disclosure"` on both pages for Playwright targeting.
+- `PackageList` adds `'relevance'` sort option (preserves server order).
+
+**TASK 3 — `/how-we-rank` page (`app/how-we-rank/page.tsx`)**
+- Full DMCC Act 2024 Schedule 20 disclosure: 4 numbered criteria cards, Featured listing rules (max 2, labelled, "Paid placement" note, excluded from count), §7 verification statement verbatim as blockquote.
+- Indexed, canonical `/how-we-rank`, WebPage JSON-LD, added to `app/sitemap.ts` and `components/layout/Footer.tsx` LEGAL_LINKS.
+
+**TASK 4 — Featured infrastructure**
+- `prisma/schema.prisma`: `isFeatured Boolean @default(false) @map("is_featured")` — SQL applied (`ADD COLUMN IF NOT EXISTS`).
+- `lib/types.ts`: `isFeatured?: boolean` added to `Package`.
+- `lib/api/db/adapter.ts`: `mapPackage` maps `isFeatured`.
+- `lib/config.ts`: `FEATURE_FEATURED_SLOTS` flag (default `false`); server-side only — never read client-side.
+- `.env.example`: documents all env vars including `FEATURE_FEATURED_SLOTS=false`.
+- `components/search/FeaturedBadge.tsx`: yellow star badge, `data-testid="featured-badge"`.
+- `components/search/PackageList.tsx`: featured section (`data-testid="featured-section"`) above neutral list, capped at `FEATURED_MAX = 2`, visible only when `featuredSlotsEnabled=true` prop (server-evaluated).
+- `app/search/packages/page.tsx`: evaluates `FEATURE_FEATURED_SLOTS` server-side, passes as `featuredSlotsEnabled` prop.
+
+**TASK 5 — Tests**
+- `tests/ranking.test.ts`: 11 tests — `scorePackage` (range, recency, completeness, isFeatured no-op, response rate) and `sortByScore` (order, immutability, empty, isFeatured no-op).
+- `tests/featured-slots.test.tsx`: 10 tests — featured section render/absent, paid-placement label, `/how-we-rank` link, cap at 2, exclusion from neutral list, disclosure always present.
+- `tests/banned-phrases.test.ts`: `/how-we-rank` metadata strings added; star-character guard (★ ☆ ⭐ 🌟) on all metadata keys.
+- `postcss.config.mjs`: switched to object plugin syntax (`{ '@tailwindcss/postcss': {} }`) — compatible with both Next.js webpack and Vite/Vitest PostCSS loading.
+
+### Key constraints upheld
+- `FEATURE_FEATURED_SLOTS` evaluated server-side only; passed as `featuredSlotsEnabled: boolean` prop — never imported or read in client components.
+- No payment/billing code added — infrastructure only.
+- `isFeatured` has no weight in `scorePackage` — confirmed by test.
+- "Priority placement" phrase never used; featured copy is "Paid placement — not ranked by our neutral criteria."
+
+### Commits (branch `feat/q6-ranking-transparency`)
+1. `feat(ranking): server-side neutral sort score`
+2. `feat(config): add FEATURE_FEATURED_SLOTS flag + .env.example`
+3. `feat(schema): add isFeatured to Package — schema, type, mapper`
+4. `feat(ui): FeaturedBadge component + CSS for disclosure and featured section`
+5. `feat(ui): disclosure line + Featured slots in PackageList and PackagesBrowse`
+6. `feat(transparency): add /how-we-rank page, sitemap entry, footer link`
+7. `feat(tests): Q6 test suite — ranking, featured slots, banned phrases`
+
+### Validation
+
+- `npx tsc --noEmit` pass
+- `npm run test` 1,810/1,810 (23 files)
 - `npm run build` 0 errors

--- a/app/how-we-rank/page.tsx
+++ b/app/how-we-rank/page.tsx
@@ -1,0 +1,276 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { JsonLdScript, graphJsonLd, webPageJsonLd } from '@/lib/seo/json-ld';
+
+export const metadata: Metadata = {
+  title: 'How We Rank Packages | PilgrimCompare',
+  description:
+    'PilgrimCompare ranks packages by data completeness, price recency, and operator response rate. No operator pays for ranking position in our default results.',
+  alternates: { canonical: '/how-we-rank' },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: 'How We Rank Packages | PilgrimCompare',
+    description:
+      'Transparent ranking criteria for Umrah and Hajj packages on PilgrimCompare. Default sort is neutral — no paid placement in organic results.',
+    url: 'https://pilgrimcompare.co.uk/how-we-rank',
+    siteName: 'PilgrimCompare',
+    type: 'website',
+    locale: 'en_GB',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'How We Rank Packages | PilgrimCompare',
+    description:
+      'Transparent ranking: completeness, recency, response rate. No operator pays for position in default results.',
+  },
+};
+
+const LAST_UPDATED = '12 June 2026';
+
+const pageJsonLd = graphJsonLd([
+  webPageJsonLd({
+    path: '/how-we-rank',
+    name: 'How We Rank Packages — PilgrimCompare',
+    description:
+      'Transparent explanation of the neutral ranking criteria used to sort packages on PilgrimCompare. Default sort is based on data completeness, price recency, and operator response rate only.',
+    dateModified: '2026-06-12',
+  }),
+]);
+
+export default function HowWeRankPage() {
+  return (
+    <>
+      <JsonLdScript data={pageJsonLd} />
+      <main className="min-h-screen bg-[var(--background)]">
+        <article className="mx-auto max-w-2xl px-5 py-12 md:px-6 md:py-16">
+
+          <header className="mb-10">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--yellow)]">
+              Transparency
+            </p>
+            <h1 className="text-3xl font-bold text-[var(--text)] md:text-4xl">
+              How we rank packages
+            </h1>
+            <p className="mt-4 text-[var(--textMuted)]">
+              The DMCC Act 2024 requires comparison services to disclose the
+              criteria they use to order results and to label any paid placement
+              clearly. This page explains exactly how PilgrimCompare ranks
+              packages — in plain English.
+            </p>
+            <p className="mt-2 text-xs text-[var(--textMuted)]">
+              Last updated: {LAST_UPDATED}
+            </p>
+          </header>
+
+          {/* Default sort */}
+          <section className="mb-10" aria-labelledby="default-sort-heading">
+            <h2
+              id="default-sort-heading"
+              className="mb-4 text-xl font-semibold text-[var(--text)]"
+            >
+              Default sort order
+            </h2>
+            <p className="mb-4 rounded-lg border border-[var(--borderSubtle)] bg-[var(--surfaceDark)] px-4 py-3 text-sm font-medium text-[var(--text)]">
+              Sorted by relevance and listing quality. No operator pays for ranking.
+            </p>
+            <p className="text-[var(--textMuted)]">
+              When you first see results — before choosing a different sort —
+              packages are ordered by a neutral quality score. The score has
+              three inputs, described below. No commercial relationship, no
+              payment, and no editorial judgement affects where a package
+              appears in the default order.
+            </p>
+          </section>
+
+          {/* The four criteria */}
+          <section className="mb-10" aria-labelledby="criteria-heading">
+            <h2
+              id="criteria-heading"
+              className="mb-6 text-xl font-semibold text-[var(--text)]"
+            >
+              The ranking criteria
+            </h2>
+
+            <div className="space-y-6">
+              <div className="rounded-lg border border-[var(--borderSubtle)] bg-[var(--surfaceDark)] p-5">
+                <div className="mb-2 flex items-center gap-3">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[rgba(255,211,29,0.12)] text-sm font-bold text-[var(--yellow)]">
+                    1
+                  </span>
+                  <h3 className="font-semibold text-[var(--text)]">
+                    Data completeness — 45%
+                  </h3>
+                </div>
+                <p className="text-sm text-[var(--textMuted)]">
+                  A listing that includes hotel names, the exact distance to the
+                  Haram, airline information, cancellation terms, deposit details,
+                  travel dates, and group type is more useful when you are
+                  comparing packages side by side. We count how many of 16
+                  optional fields are filled in and score the listing
+                  proportionally. An operator improves their score simply by
+                  providing complete information — not by paying.
+                </p>
+              </div>
+
+              <div className="rounded-lg border border-[var(--borderSubtle)] bg-[var(--surfaceDark)] p-5">
+                <div className="mb-2 flex items-center gap-3">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[rgba(255,211,29,0.12)] text-sm font-bold text-[var(--yellow)]">
+                    2
+                  </span>
+                  <h3 className="font-semibold text-[var(--text)]">
+                    Price confirmation recency — 35%
+                  </h3>
+                </div>
+                <p className="text-sm text-[var(--textMuted)]">
+                  A package that was updated recently is more likely to have
+                  accurate pricing. We use the date the operator last updated
+                  their listing as a proxy for price freshness. A listing updated
+                  in the last 7 days scores maximum; listings older than 90 days
+                  score zero on this dimension. Operators keep their score high
+                  by keeping their listings current.
+                </p>
+              </div>
+
+              <div className="rounded-lg border border-[var(--borderSubtle)] bg-[var(--surfaceDark)] p-5">
+                <div className="mb-2 flex items-center gap-3">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[rgba(255,211,29,0.12)] text-sm font-bold text-[var(--yellow)]">
+                    3
+                  </span>
+                  <h3 className="font-semibold text-[var(--text)]">
+                    Operator response rate — 20%
+                  </h3>
+                </div>
+                <p className="text-sm text-[var(--textMuted)]">
+                  Operators who reply to enquiries quickly give travellers a
+                  better experience. This dimension will use measured response
+                  times once enough enquiry data exists. Until then, all
+                  operators receive an equal neutral score on this input so no
+                  operator is unfairly penalised or rewarded before real data
+                  is available.
+                </p>
+              </div>
+
+              <div className="rounded-lg border border-[var(--borderSubtle)] bg-[var(--surfaceDark)] p-5">
+                <div className="mb-2 flex items-center gap-3">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[rgba(255,211,29,0.12)] text-sm font-bold text-[var(--yellow)]">
+                    4
+                  </span>
+                  <h3 className="font-semibold text-[var(--text)]">
+                    Relevance to your search
+                  </h3>
+                </div>
+                <p className="text-sm text-[var(--textMuted)]">
+                  Packages you see have already been filtered to match your
+                  chosen criteria (departure city, budget, hotel stars, distance
+                  to Haram, and so on). Every result in the list has passed your
+                  active filters — so within those results, the other three
+                  criteria determine the order.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          {/* Featured slots */}
+          <section className="mb-10" aria-labelledby="featured-heading">
+            <h2
+              id="featured-heading"
+              className="mb-4 text-xl font-semibold text-[var(--text)]"
+            >
+              Featured listings
+            </h2>
+            <p className="mb-3 text-[var(--textMuted)]">
+              In the future, operators will be able to pay for a{' '}
+              <strong className="text-[var(--text)]">Featured</strong> placement.
+              When Featured slots are active, the following rules apply without
+              exception:
+            </p>
+            <ul className="space-y-2 text-sm text-[var(--textMuted)]">
+              <li className="flex gap-2">
+                <span className="mt-0.5 shrink-0 text-[var(--yellow)]">✓</span>
+                Featured packages appear in a clearly labelled{' '}
+                <strong className="text-[var(--text)]">&ldquo;Featured&rdquo;</strong>{' '}
+                section above the neutral results — the label is at the slot
+                itself, not in a footnote.
+              </li>
+              <li className="flex gap-2">
+                <span className="mt-0.5 shrink-0 text-[var(--yellow)]">✓</span>
+                The section note reads: &ldquo;Paid placement — not ranked by our
+                neutral criteria.&rdquo;
+              </li>
+              <li className="flex gap-2">
+                <span className="mt-0.5 shrink-0 text-[var(--yellow)]">✓</span>
+                A maximum of 2 Featured packages per list view.
+              </li>
+              <li className="flex gap-2">
+                <span className="mt-0.5 shrink-0 text-[var(--yellow)]">✓</span>
+                Featured packages are excluded from the neutral results count
+                shown at the top of the page.
+              </li>
+              <li className="flex gap-2">
+                <span className="mt-0.5 shrink-0 text-[var(--yellow)]">✓</span>
+                Featured status has no influence on a package&rsquo;s neutral
+                ranking score — if Featured is switched off, the package ranks
+                on its merits like any other.
+              </li>
+            </ul>
+            <p className="mt-4 text-sm text-[var(--textMuted)]">
+              No operator is currently featured. Featured slots are not yet
+              active on this site.
+            </p>
+          </section>
+
+          {/* Verification statement — verbatim from §7 of standards doc */}
+          <section className="mb-10" aria-labelledby="verification-heading">
+            <h2
+              id="verification-heading"
+              className="mb-4 text-xl font-semibold text-[var(--text)]"
+            >
+              How we verify operators
+            </h2>
+            <blockquote className="rounded-lg border-l-4 border-[var(--yellow)] bg-[var(--surfaceDark)] px-5 py-4 text-sm text-[var(--textMuted)]">
+              Before any operator is listed, we check: (1) their ATOL number
+              against the CAA&rsquo;s public register, (2) their company status at
+              Companies House, (3) that they have a real, verifiable UK trading
+              address. Verification confirms these checks at the time of listing.
+              It is not a guarantee of service quality, financial protection for
+              your specific booking, or future conduct.
+            </blockquote>
+          </section>
+
+          {/* Footer links */}
+          <footer className="border-t border-[var(--borderSubtle)] pt-8">
+            <p className="mb-4 text-sm text-[var(--textMuted)]">
+              Questions about our ranking or verification approach?{' '}
+              <a
+                href="mailto:support@pilgrimcompare.co.uk"
+                className="text-[var(--accent)] underline underline-offset-2 hover:text-[var(--accentHover)]"
+              >
+                Contact us
+              </a>
+            </p>
+            <nav aria-label="Related pages" className="flex flex-wrap gap-4 text-sm">
+              <Link
+                href="/how-it-works"
+                className="text-[var(--accent)] underline underline-offset-2 hover:text-[var(--accentHover)]"
+              >
+                How PilgrimCompare works
+              </Link>
+              <Link
+                href="/terms"
+                className="text-[var(--accent)] underline underline-offset-2 hover:text-[var(--accentHover)]"
+              >
+                Terms of Use
+              </Link>
+              <Link
+                href="/search/packages"
+                className="text-[var(--accent)] underline underline-offset-2 hover:text-[var(--accentHover)]"
+              >
+                Compare packages
+              </Link>
+            </nav>
+          </footer>
+        </article>
+      </main>
+    </>
+  );
+}

--- a/app/search/packages/page.tsx
+++ b/app/search/packages/page.tsx
@@ -5,6 +5,7 @@ import { filterByParams } from '@/components/search/search-utils';
 import { Repository } from '@/lib/api/repository';
 import type { Package as CataloguePackage } from '@/lib/types';
 import { JsonLdScript, faqPageJsonLd, graphJsonLd, searchResultsJsonLd, webPageJsonLd } from '@/lib/seo/json-ld';
+import { FEATURE_FEATURED_SLOTS } from '@/lib/config';
 import styles from '@/components/search/packages.module.css';
 
 /**
@@ -158,7 +159,7 @@ export default async function SearchPackagesPage({ searchParams }: SearchPackage
           </main>
         }
       >
-        <SearchPackagesClient allPackages={allPackages} />
+        <SearchPackagesClient allPackages={allPackages} featuredSlotsEnabled={FEATURE_FEATURED_SLOTS} />
       </Suspense>
     </>
   );

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -21,6 +21,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${baseUrl}/packages`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.8 },
     { url: `${baseUrl}/search/packages`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.6 },
     { url: `${baseUrl}/how-it-works`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${baseUrl}/how-we-rank`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.6 },
     { url: `${baseUrl}/partner`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.5 },
     { url: `${baseUrl}/privacy`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.3 },
     { url: `${baseUrl}/terms`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.3 },

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -8,6 +8,7 @@ import { LEGAL_ENTITY_BLOCK } from '@/lib/legal';
 
 const LEGAL_LINKS = [
   { href: '/how-it-works', label: 'How it works' },
+  { href: '/how-we-rank', label: 'How we rank' },
   { href: '/terms', label: 'Terms of Use' },
   { href: '/privacy', label: 'Privacy Policy' },
 ];

--- a/components/packages/PackagesBrowse.tsx
+++ b/components/packages/PackagesBrowse.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useEffect, useMemo, useState, useTransition } from 'react'
 import type { Package, OperatorProfile } from '@/lib/types'
+import { NEUTRAL_SORT_DISCLOSURE } from '@/lib/content-rules'
 import { mapPackageToComparison, handleComparisonSelection } from '@/lib/comparison'
 import { ComparisonTable } from '@/components/request/ComparisonTable'
 import { CURRENCY_CHANGE_EVENT, getRegionSettings } from '@/lib/i18n/region'
@@ -204,6 +205,15 @@ export function PackagesBrowse({ packages, error }: PackagesBrowseProps) {
             <option value="price-asc">Lowest to highest</option>
             <option value="price-desc">Highest to lowest</option>
           </select>
+          <p className="text-xs text-[var(--textMuted)]" data-testid="sort-disclosure">
+            {NEUTRAL_SORT_DISCLOSURE}{' '}
+            <a
+              href="/how-we-rank"
+              className="underline underline-offset-2 hover:text-[var(--text)] focus-visible:outline-2 focus-visible:outline-[var(--yellow)] focus-visible:outline-offset-2"
+            >
+              How we rank
+            </a>
+          </p>
         </div>
 
         <div className="flex flex-col gap-2">

--- a/components/search/FeaturedBadge.tsx
+++ b/components/search/FeaturedBadge.tsx
@@ -1,0 +1,27 @@
+/**
+ * FeaturedBadge — rendered at the Featured slot itself, never in a footnote.
+ *
+ * DMCC Act 2024 Schedule 20: paid placement must be visually distinct and
+ * labelled at the slot. This component satisfies that requirement.
+ * Only shown when FEATURE_FEATURED_SLOTS=true and isFeatured=true.
+ */
+export function FeaturedBadge() {
+  return (
+    <span
+      data-testid="featured-badge"
+      className="inline-flex items-center gap-1 rounded-full border border-[var(--yellow)] bg-[rgba(255,211,29,0.12)] px-2.5 py-0.5 text-[0.6875rem] font-700 uppercase tracking-wide text-[var(--yellow)]"
+      aria-label="Featured listing"
+    >
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 10 10"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <polygon points="5,0 6.5,3.5 10,3.8 7.5,6.3 8.2,10 5,8.2 1.8,10 2.5,6.3 0,3.8 3.5,3.5" />
+      </svg>
+      Featured
+    </span>
+  );
+}

--- a/components/search/PackageList.tsx
+++ b/components/search/PackageList.tsx
@@ -19,17 +19,20 @@ import {
 import PackageCard from './PackageCard';
 import CompareBar, { type CompareBarItem } from './CompareBar';
 import { FilterOverlay } from './FilterOverlay';
+import { FeaturedBadge } from './FeaturedBadge';
+import { NEUTRAL_SORT_DISCLOSURE } from '@/lib/content-rules';
 import styles from './packages.module.css';
 
 const COMPARE_MAX = 3;
 const COMPARE_MIN = 2;
+const FEATURED_MAX = 2;
 
 const SHORTLIST_STORAGE_KEY = 'kb_shortlist_packages';
 const uniqueIds = (ids: string[]) => Array.from(new Set(ids));
 
 export type { SearchPackageDisplay } from './search-utils';
 
-type SortOption = 'price-asc' | 'price-desc' | 'rating' | 'distance';
+type SortOption = 'relevance' | 'price-asc' | 'price-desc' | 'rating' | 'distance';
 
 
 interface PackageListProps {
@@ -38,6 +41,8 @@ interface PackageListProps {
   onFilter?: () => void;
   sortBy?: SortOption;
   onSortChange?: (sort: SortOption) => void;
+  /** Evaluated server-side from FEATURE_FEATURED_SLOTS env var. Never pass client state here. */
+  featuredSlotsEnabled?: boolean;
 }
 
 const PackageList: React.FC<PackageListProps> = ({
@@ -46,6 +51,7 @@ const PackageList: React.FC<PackageListProps> = ({
   onFilter,
   sortBy: sortByProp,
   onSortChange,
+  featuredSlotsEnabled = false,
 }) => {
   const [shortlistedPackages, setShortlistedPackages] = useState<string[]>([]);
   const [shortlistLoaded, setShortlistLoaded] = useState(false);
@@ -58,7 +64,7 @@ const PackageList: React.FC<PackageListProps> = ({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const [internalSort, setInternalSort] = useState<SortOption>('price-asc');
+  const [internalSort, setInternalSort] = useState<SortOption>('relevance');
   const sortBy = sortByProp ?? internalSort;
   const [isSortOpen, setIsSortOpen] = useState(false);
   const sortRef = useRef<HTMLDivElement>(null);
@@ -150,10 +156,31 @@ const PackageList: React.FC<PackageListProps> = ({
 
   const shortlistCount = shortlistedPackages.length;
 
-  // Sort packages
+  // Split featured from normal when flag is on.
+  // Featured packages are excluded from the neutral sort and shown above it.
+  const featuredPackages = useMemo(
+    () =>
+      featuredSlotsEnabled && !shortlistOnly
+        ? packages.filter((p) => p.isFeatured).slice(0, FEATURED_MAX)
+        : [],
+    [packages, featuredSlotsEnabled, shortlistOnly]
+  );
+
+  const normalPackages = useMemo(
+    () =>
+      featuredSlotsEnabled
+        ? packages.filter((p) => !p.isFeatured)
+        : packages,
+    [packages, featuredSlotsEnabled]
+  );
+
+  // Sort normal packages (featured are already above, not sorted with normal results)
   const sortedPackages = useMemo(() => {
-    const sorted = [...packages];
+    const sorted = [...normalPackages];
     switch (sortBy) {
+      case 'relevance':
+        // Server already applied neutral quality sort — preserve that order.
+        return sorted;
       case 'price-asc':
         return sorted.sort((a, b) => a.price - b.price);
       case 'price-desc':
@@ -170,7 +197,7 @@ const PackageList: React.FC<PackageListProps> = ({
       default:
         return sorted;
     }
-  }, [packages, sortBy]);
+  }, [normalPackages, sortBy]);
 
   const listPackages = shortlistOnly
     ? sortedPackages.filter((p) => shortlistedPackages.includes(p.id))
@@ -282,6 +309,7 @@ const PackageList: React.FC<PackageListProps> = ({
                   aria-label="Sort options"
                 >
                   {([
+                    { value: 'relevance' as SortOption, label: 'Relevance (default)' },
                     { value: 'price-asc' as SortOption, label: 'Price: Low to High' },
                     { value: 'price-desc' as SortOption, label: 'Price: High to Low' },
                     { value: 'rating' as SortOption, label: 'Hotel rating' },
@@ -309,6 +337,14 @@ const PackageList: React.FC<PackageListProps> = ({
             </div>
           </div>
         </div>
+
+        {/* Neutral sort disclosure — DMCC Act 2024 Schedule 20 */}
+        <p className={styles.sortDisclosure} data-testid="sort-disclosure">
+          {NEUTRAL_SORT_DISCLOSURE}{' '}
+          <a href="/how-we-rank" className={styles.sortDisclosureLink}>
+            How we rank
+          </a>
+        </p>
 
         {activeFilters.length > 0 && (
           <div className={styles.activeFilters} aria-label="Active filters">
@@ -375,6 +411,44 @@ const PackageList: React.FC<PackageListProps> = ({
             Reset filters
           </button>
         </div>
+      )}
+
+      {/* Featured section — above neutral results, capped at 2, flag-gated */}
+      {featuredPackages.length > 0 && (
+        <section className={styles.featuredSection} aria-label="Featured packages" data-testid="featured-section">
+          <header className={styles.featuredSectionHeader}>
+            <FeaturedBadge />
+            <span className={styles.featuredSectionNote}>
+              Paid placement — not ranked by our neutral criteria.{' '}
+              <a href="/how-we-rank" className={styles.sortDisclosureLink}>
+                How we rank
+              </a>
+            </span>
+          </header>
+          {featuredPackages.map((pkg) => {
+            const catPkg = cataloguePackages?.find((cp) => cp.id === pkg.id);
+            const operator = catPkg ? operatorsById[catPkg.operatorId] : undefined;
+            const inclusions = catPkg ? [
+              { label: 'Visa', included: catPkg.inclusions?.visa ?? false },
+              { label: 'Flights', included: catPkg.inclusions?.flights ?? false },
+              { label: 'Transfers', included: catPkg.inclusions?.transfers ?? false },
+              { label: 'Meals', included: catPkg.inclusions?.meals ?? false },
+            ].filter((chip) => chip.included) : undefined;
+            return (
+              <PackageCard
+                key={pkg.id}
+                package={pkg}
+                isShortlisted={shortlistedPackages.includes(pkg.id)}
+                isCompareSelected={selectedCompareIds.includes(pkg.id)}
+                onAddToShortlist={onToggleShortlist}
+                onToggleCompare={onToggleCompare}
+                compareFull={compareFull}
+                operator={operator}
+                inclusions={inclusions}
+              />
+            );
+          })}
+        </section>
       )}
 
       <section

--- a/components/search/SearchPackagesClient.tsx
+++ b/components/search/SearchPackagesClient.tsx
@@ -9,14 +9,15 @@ import styles from './packages.module.css';
 
 interface SearchPackagesClientProps {
   allPackages: CataloguePackage[];
+  featuredSlotsEnabled: boolean;
 }
 
-const VALID_SORTS = ['price-asc', 'price-desc', 'rating', 'distance'] as const;
+const VALID_SORTS = ['relevance', 'price-asc', 'price-desc', 'rating', 'distance'] as const;
 type SortOption = typeof VALID_SORTS[number];
 const toSortOption = (v: string | null): SortOption =>
-  VALID_SORTS.includes(v as SortOption) ? (v as SortOption) : 'price-asc';
+  VALID_SORTS.includes(v as SortOption) ? (v as SortOption) : 'relevance';
 
-export function SearchPackagesClient({ allPackages }: SearchPackagesClientProps) {
+export function SearchPackagesClient({ allPackages, featuredSlotsEnabled }: SearchPackagesClientProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -50,6 +51,7 @@ export function SearchPackagesClient({ allPackages }: SearchPackagesClientProps)
         cataloguePackages={filteredPackages}
         sortBy={sortBy}
         onSortChange={handleSortChange}
+        featuredSlotsEnabled={featuredSlotsEnabled}
       />
     </main>
   );

--- a/components/search/packages.module.css
+++ b/components/search/packages.module.css
@@ -597,6 +597,60 @@
   outline-offset: 2px;
 }
 
+/* ─── Sort disclosure — DMCC Act 2024 Schedule 20 ─────────────────────── */
+.sortDisclosure {
+  font-size: 0.75rem;
+  color: var(--textMuted);
+  line-height: 1.4;
+  margin-top: 0.5rem;
+  /* Wraps cleanly at 390px — no truncation */
+  white-space: normal;
+  word-break: break-word;
+}
+
+.sortDisclosureLink {
+  color: var(--textMuted);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.sortDisclosureLink:hover {
+  color: var(--text);
+}
+
+.sortDisclosureLink:focus-visible {
+  outline: 2px solid var(--yellow);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* ─── Featured section — above the neutral-sorted list ────────────────── */
+.featuredSection {
+  margin-bottom: 1.5rem;
+}
+
+.featuredSectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid rgba(255, 211, 29, 0.2);
+}
+
+.featuredSectionLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--yellow);
+}
+
+.featuredSectionNote {
+  font-size: 0.75rem;
+  color: var(--textMuted);
+}
+
 /* ─── Sort dropdown ────────────────────────────────────────────────────── */
 .sortWrapper {
   position: relative;

--- a/components/search/search-utils.ts
+++ b/components/search/search-utils.ts
@@ -30,6 +30,7 @@ export interface SearchPackageDisplay {
   price: number;
   currency: string;
   priceNote: string;
+  isFeatured: boolean;
 }
 
 const PLACEHOLDER_IMAGE =
@@ -157,5 +158,6 @@ export function toSearchDisplay(pkg: CataloguePackage): SearchPackageDisplay {
     price: pkg.pricePerPerson,
     currency: pkg.currency,
     priceNote: 'per person',
+    isFeatured: pkg.isFeatured ?? false,
   };
 }

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -6,17 +6,29 @@
 
 ## Branch & goal
 
-- **Branch:** `feat/q5-seo` (off `feat/q4-mobile-polish`) → PR → `dev` → `main`
-- **Goal:** Q5 complete — SEO metadata, structured data, sitemap, robots, OG/Twitter, banned-phrase CI test. Next: Q6 ranking transparency + Featured infrastructure.
-- **Current source-of-truth note:** Q5 verified 2026-06-12. Full detail in `AI_NOTES.md` §21.
+- **Branch:** `feat/q6-ranking-transparency` (off `dev`) → PR → `dev` → `main`
+- **Goal:** Q6 complete — neutral sort, DMCC disclosure, /how-we-rank page, Featured infrastructure. Quality prompt queue Q1–Q6 all done. Next: Gate 3 operator onboarding.
+- **Current source-of-truth note:** Q6 verified 2026-06-12. Full detail in `AI_NOTES.md` §22.
 - **Canonical handover:** `AI_NOTES.md` is the single source of truth for verified status, implementation posture, and pending areas.
 
 ## What works (verified)
 
-- **Tests**: `npm run test` passes (21 files, 1,425/1,425 tests) — verified 2026-06-12.
+- **Tests**: `npm run test` passes (23 files, 1,810/1,810 tests) — verified 2026-06-12.
 - **Build**: `npm run build` passes with 0 errors — verified 2026-06-12.
 - **TypeScript**: `npx tsc --noEmit` passes — verified 2026-06-12.
 - **Architecture decision**: Supabase + Prisma + Upstash Redis is the correct target/production architecture. MockDB is not the production architecture, but production-facing MockDB imports remain and are now documented as launch blockers in `AI_NOTES.md` §0.
+
+## Changes made in this session (2026-06-12 — Q6 Ranking Transparency + Featured Infrastructure)
+
+| Task | What | Files |
+| ---- | ---- | ----- |
+| TASK1 neutral sort | `lib/ranking.ts`: `scorePackage` (45% completeness + 35% recency + 20% response rate) + `sortByScore`. `Repository.listPackages` calls `sortByScore` server-side. | `lib/ranking.ts`, `lib/api/repository.ts` |
+| TASK2 disclosure | `NEUTRAL_SORT_DISCLOSURE` near every sort control, linked to `/how-we-rank`. `'relevance'` sort option added to PackageList preserving server order. | `components/search/PackageList.tsx`, `components/packages/PackagesBrowse.tsx` |
+| TASK3 /how-we-rank | Full DMCC Act 2024 §20 disclosure page: 4 criteria cards, Featured rules (max 2, labelled), §7 verification verbatim. Indexed, sitemap, footer link. | `app/how-we-rank/page.tsx`, `app/sitemap.ts`, `components/layout/Footer.tsx` |
+| TASK4 Featured infra | DB column `is_featured`, `isFeatured` in type/adapter. `FEATURE_FEATURED_SLOTS` flag (server-only). `FeaturedBadge` component. PackageList: featured section above neutral, capped at 2, flag-gated. | `prisma/schema.prisma`, `lib/types.ts`, `lib/api/db/adapter.ts`, `lib/config.ts`, `.env.example`, `components/search/FeaturedBadge.tsx`, `components/search/PackageList.tsx`, `app/search/packages/page.tsx` |
+| TASK5 tests | 11 ranking tests, 10 featured-slot tests, /how-we-rank metadata + star-char guard in banned-phrases. PostCSS config fixed for Vite/Vitest. | `tests/ranking.test.ts`, `tests/featured-slots.test.tsx`, `tests/banned-phrases.test.ts`, `postcss.config.mjs` |
+
+**Verification:** `npx tsc --noEmit` pass · `npm run test` 1,810/1,810 (23 files) · `npm run build` 0 errors.
 
 ## Changes made in this session (2026-06-12 — Q5 SEO Pass)
 

--- a/lib/api/db/adapter.ts
+++ b/lib/api/db/adapter.ts
@@ -222,6 +222,7 @@ const mapPackage = (pkg: PrismaPackage): Package => ({
   inclusions: pkg.inclusions as unknown as Package['inclusions'],
   notes: pkg.notes ?? undefined,
   images: pkg.images,
+  isFeatured: pkg.isFeatured,
 });
 
 const mapComplaint = (c: PrismaComplaint): Complaint => ({

--- a/lib/api/repository.ts
+++ b/lib/api/repository.ts
@@ -1,4 +1,5 @@
 import { MockDB } from './mock-db';
+import { sortByScore } from '@/lib/ranking';
 import { UK_DEPARTURE_AIRPORTS } from '@/lib/airports';
 import {
   ANALYTICS_EVENT_TYPES,
@@ -1105,7 +1106,7 @@ export const Repository = {
 
   listPackages: async (): Promise<Package[]> => {
     const all = await store().getPackages();
-    return all.filter((p) => p.status === 'published');
+    return sortByScore(all.filter((p) => p.status === 'published'));
   },
 
   getPackageBySlug: async (slug: string): Promise<Package | undefined> => {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -7,6 +7,25 @@
 export const FEATURE_USE_REAL_DB =
   process.env.FEATURE_USE_REAL_DB === 'true';
 
+/**
+ * Whether Featured package slots are active in the list UI.
+ *
+ * Default FALSE — no operator is featured at launch.
+ *
+ * When true: up to 2 Featured packages appear ABOVE the neutral-sorted list,
+ * in a visually distinct section labelled "Featured" at the slot itself.
+ * Featured packages are excluded from the neutral-sorted results count.
+ * Featured status does NOT affect the neutral sort score (scorePackage).
+ *
+ * NEVER read this flag client-side. Evaluate on the server and pass the
+ * result as a `featuredSlotsEnabled: boolean` prop to list components.
+ *
+ * Set to true only when at least one operator has isFeatured=true in the DB
+ * and the phase-2 Featured placement terms have been agreed and disclosed.
+ */
+export const FEATURE_FEATURED_SLOTS =
+  process.env.FEATURE_FEATURED_SLOTS === 'true';
+
 /** Whether we're running in test mode (Vitest) */
 export const IS_TEST_ENV = process.env.NODE_ENV === 'test';
 

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -1,0 +1,95 @@
+import type { Package } from '@/lib/types';
+
+/**
+ * Neutral listing quality score for PilgrimCompare packages.
+ *
+ * Required by DMCC Act 2024 Schedule 20: default sort order must use only
+ * disclosed, non-commercial criteria. No operator pays for ranking.
+ *
+ * HOW THE SCORE WORKS (plain English):
+ *
+ *   1. DATA COMPLETENESS (45%)
+ *      A listing with more filled-in details — hotel names, airline, exact
+ *      distance to Haram, cancellation policy, deposit terms, group type,
+ *      highlights, travel dates — is more useful to someone comparing side
+ *      by side. Score = fraction of 16 optional fields that are filled in
+ *      (0 = nothing filled; 1 = everything filled).
+ *
+ *   2. PRICE CONFIRMATION RECENCY (35%)
+ *      A package updated recently is more likely to have accurate pricing.
+ *      Full score (1.0) if updated within the last 7 days; decays linearly
+ *      to 0.0 at 90 days. Older than 90 days scores 0.
+ *
+ *   3. OPERATOR RESPONSE RATE (20%)
+ *      How quickly the operator replies to enquiries. Currently neutral 0.5
+ *      for all operators — no measured response-rate data exists yet.
+ *      When real per-operator data is available, pass it as `responseRate`.
+ *
+ *   RELEVANCE: packages reach this function only after the user's active
+ *   filters have already been applied — every package here has already
+ *   passed the user's criteria. Within that filtered set, completeness and
+ *   recency proxy relevance: a complete, fresh listing gives the traveller
+ *   what they need to make a decision.
+ *
+ * No commercial, paid, editorial, or isFeatured input affects this score.
+ * The score is deterministic given the same package data.
+ */
+
+const COMPLETENESS_WEIGHT = 0.45;
+const RECENCY_WEIGHT = 0.35;
+const RESPONSE_RATE_WEIGHT = 0.20;
+
+const RECENCY_FRESH_DAYS = 7;
+const RECENCY_STALE_DAYS = 90;
+const MS_PER_DAY = 86_400_000;
+
+type FieldCheck = (p: Package) => boolean;
+
+const OPTIONAL_FIELDS: FieldCheck[] = [
+  (p) => p.hotelMakkahStars != null,
+  (p) => p.hotelMadinahStars != null,
+  (p) => !!p.hotelMakkahName,
+  (p) => !!p.hotelMadinahName,
+  (p) => p.distanceToHaramMakkahMetres != null,
+  (p) => p.distanceToHaramMadinahMetres != null,
+  (p) => !!p.airline,
+  (p) => !!p.departureAirport,
+  (p) => !!p.flightType,
+  (p) => p.depositAmount != null,
+  (p) => p.paymentPlanAvailable != null,
+  (p) => !!p.cancellationPolicy,
+  (p) => Array.isArray(p.highlights) && p.highlights.length > 0,
+  (p) => !!p.groupType,
+  (p) => !!p.seasonLabel,
+  (p) => !!p.dateWindow?.start,
+];
+
+function completenessScore(pkg: Package): number {
+  const filled = OPTIONAL_FIELDS.filter((check) => check(pkg)).length;
+  return filled / OPTIONAL_FIELDS.length;
+}
+
+function recencyScore(updatedAt: string | undefined): number {
+  if (!updatedAt) return 0;
+  const ageDays = (Date.now() - new Date(updatedAt).getTime()) / MS_PER_DAY;
+  if (ageDays <= RECENCY_FRESH_DAYS) return 1.0;
+  if (ageDays >= RECENCY_STALE_DAYS) return 0.0;
+  return 1 - (ageDays - RECENCY_FRESH_DAYS) / (RECENCY_STALE_DAYS - RECENCY_FRESH_DAYS);
+}
+
+/**
+ * Neutral listing quality score for one package. Higher = ranked first.
+ * Range 0–1. Safe to call with no response-rate data (defaults to neutral 0.5).
+ */
+export function scorePackage(pkg: Package, responseRate = 0.5): number {
+  return (
+    COMPLETENESS_WEIGHT * completenessScore(pkg) +
+    RECENCY_WEIGHT * recencyScore(pkg.updatedAt) +
+    RESPONSE_RATE_WEIGHT * responseRate
+  );
+}
+
+/** Return a new array sorted by neutral listing quality score, highest first. */
+export function sortByScore(packages: Package[]): Package[] {
+  return [...packages].sort((a, b) => scorePackage(b) - scorePackage(a));
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -397,6 +397,7 @@ export interface Package {
   notes?: string; // sanitized, no HTML
   images?: string[];
   imageUrl?: string;
+  isFeatured?: boolean;
 }
 
 export type ComplaintCategory =

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,5 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
 };
-
-export default config;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -414,6 +414,7 @@ model Package {
   inclusions                 Json
   notes                      String?
   images                     String[]
+  isFeatured                 Boolean  @default(false) @map("is_featured")
 
   // Relations
   operator        OperatorProfile  @relation(fields: [operatorId], references: [id])

--- a/tests/banned-phrases.test.ts
+++ b/tests/banned-phrases.test.ts
@@ -83,6 +83,14 @@ const METADATA_STRINGS: Record<string, string> = {
   'partner.og.title': 'List Your Umrah & Hajj Packages | PilgrimCompare',
   'partner.og.description': 'Reach UK travellers planning Umrah and Hajj. Verified operators only. No upfront fees.',
 
+  // app/how-we-rank/page.tsx
+  'how-we-rank.title': 'How We Rank Packages | PilgrimCompare',
+  'how-we-rank.description': 'PilgrimCompare ranks packages by data completeness, price recency, and operator response rate. No operator pays for ranking position in our default results.',
+  'how-we-rank.og.title': 'How We Rank Packages | PilgrimCompare',
+  'how-we-rank.og.description': 'Transparent ranking criteria for Umrah and Hajj packages on PilgrimCompare. Default sort is neutral — no paid placement in organic results.',
+  'how-we-rank.twitter.title': 'How We Rank Packages | PilgrimCompare',
+  'how-we-rank.twitter.description': 'Transparent ranking: completeness, recency, response rate. No operator pays for position in default results.',
+
   // app/login/page.tsx
   'login.title': 'Sign In | PilgrimCompare',
   'login.description': 'Sign in to your PilgrimCompare traveller or operator account.',
@@ -111,6 +119,21 @@ describe('BANNED_METADATA_PHRASES — lib/content-rules integrity', () => {
       expect(lower, `NEUTRAL_SORT_DISCLOSURE contains banned phrase: "${phrase}"`).not.toContain(phrase)
     }
   })
+})
+
+describe('Star character guard — metadata must not use decorative rating stars', () => {
+  const STAR_CHARS = ['★', '☆', '⭐', '🌟']
+
+  for (const [key, value] of Object.entries(METADATA_STRINGS)) {
+    for (const star of STAR_CHARS) {
+      it(`"${key}" must not contain star character: "${star}"`, () => {
+        expect(
+          value,
+          `Star character "${star}" found in metadata key "${key}":\n  "${value}"`
+        ).not.toContain(star)
+      })
+    }
+  }
 })
 
 describe('Metadata banned-phrase scan', () => {

--- a/tests/featured-slots.test.tsx
+++ b/tests/featured-slots.test.tsx
@@ -1,0 +1,212 @@
+import React, { act } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { createRoot, Root } from 'react-dom/client';
+import type { SearchPackageDisplay } from '@/components/search/search-utils';
+
+// --- next/navigation mock ---------------------------------------------------
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  usePathname: () => '/search/packages',
+}));
+
+// --- next/link mock ----------------------------------------------------------
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+// --- fetch stub for operators ------------------------------------------------
+vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+  json: () => Promise.resolve({ operators: [] }),
+}));
+
+// --- localStorage stub -------------------------------------------------------
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { store = {}; },
+  };
+})();
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
+
+// ---------------------------------------------------------------------------
+
+const makePackage = (id: string, isFeatured: boolean): SearchPackageDisplay => ({
+  id,
+  slug: id,
+  departure: { date: '2026-09-01', duration: '5h 30m', route: 'LHR → JED' },
+  return: { date: '2026-09-15', duration: '5h 30m', route: 'JED → LHR' },
+  makkahHotel: { name: `Makkah Hotel ${id}`, location: 'Makkah', rating: 4, distance: '200m', image: '' },
+  madinaHotel: { name: `Madinah Hotel ${id}`, location: 'Madinah', rating: 4, distance: '300m', image: '' },
+  price: 1500,
+  currency: 'GBP',
+  priceNote: 'per person',
+  isFeatured,
+});
+
+async function renderPackageList(
+  packages: SearchPackageDisplay[],
+  featuredSlotsEnabled: boolean
+): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const { default: PackageList } = await import('@/components/search/PackageList');
+
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <PackageList
+        packages={packages}
+        featuredSlotsEnabled={featuredSlotsEnabled}
+      />
+    );
+  });
+
+  return { container, root };
+}
+
+describe('Featured slots — flag OFF (default)', () => {
+  it('does not render featured section when flag is false', async () => {
+    const pkgs = [
+      makePackage('pkg-featured', true),
+      makePackage('pkg-normal', false),
+    ];
+    const { container, root } = await renderPackageList(pkgs, false);
+
+    expect(container.querySelector('[data-testid="featured-section"]')).toBeNull();
+
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+
+  it('renders all packages in normal results when flag is false', async () => {
+    const pkgs = [
+      makePackage('pkg-featured', true),
+      makePackage('pkg-normal', false),
+    ];
+    const { container, root } = await renderPackageList(pkgs, false);
+
+    const normalSection = container.querySelector('[aria-label="Search results"]');
+    expect(normalSection).not.toBeNull();
+    // Both appear in normal list (identified by data-testid)
+    expect(normalSection!.querySelector('[data-testid="package-card-pkg-featured"]')).not.toBeNull();
+    expect(normalSection!.querySelector('[data-testid="package-card-pkg-normal"]')).not.toBeNull();
+
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+});
+
+describe('Featured slots — flag ON', () => {
+  it('renders the featured section when flag is true and isFeatured packages exist', async () => {
+    const pkgs = [
+      makePackage('pkg-featured', true),
+      makePackage('pkg-normal', false),
+    ];
+    const { container, root } = await renderPackageList(pkgs, true);
+
+    expect(container.querySelector('[data-testid="featured-section"]')).not.toBeNull();
+
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+
+  it('featured section has "Paid placement" label text', async () => {
+    const pkgs = [makePackage('pkg-f1', true), makePackage('pkg-normal', false)];
+    const { container, root } = await renderPackageList(pkgs, true);
+
+    const featuredSection = container.querySelector('[data-testid="featured-section"]');
+    expect(featuredSection!.textContent).toContain('Paid placement');
+
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+
+  it('featured section links to /how-we-rank', async () => {
+    const pkgs = [makePackage('pkg-f1', true), makePackage('pkg-normal', false)];
+    const { container, root } = await renderPackageList(pkgs, true);
+
+    const featuredSection = container.querySelector('[data-testid="featured-section"]');
+    const link = featuredSection!.querySelector('a[href="/how-we-rank"]');
+    expect(link).not.toBeNull();
+
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+
+  it('caps featured packages at 2 even when more are isFeatured', async () => {
+    const pkgs = [
+      makePackage('pkg-f1', true),
+      makePackage('pkg-f2', true),
+      makePackage('pkg-f3', true),
+      makePackage('pkg-normal', false),
+    ];
+    const { container, root } = await renderPackageList(pkgs, true);
+
+    const featuredSection = container.querySelector('[data-testid="featured-section"]');
+    // PackageCards inside featured section — count heading elements as proxy
+    const cards = featuredSection!.querySelectorAll('[data-testid^="package-card"]');
+    expect(cards.length).toBeLessThanOrEqual(2);
+
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+
+  it('featured package does NOT appear in neutral results section', async () => {
+    const pkgs = [
+      makePackage('pkg-f1', true),
+      makePackage('pkg-normal', false),
+    ];
+    const { container, root } = await renderPackageList(pkgs, true);
+
+    const neutralSection = container.querySelector('[aria-label="Search results"]');
+    expect(neutralSection!.querySelector('[data-testid="package-card-pkg-f1"]')).toBeNull();
+    expect(neutralSection!.querySelector('[data-testid="package-card-pkg-normal"]')).not.toBeNull();
+
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+
+  it('does not render featured section when no packages have isFeatured=true', async () => {
+    const pkgs = [makePackage('pkg-1', false), makePackage('pkg-2', false)];
+    const { container, root } = await renderPackageList(pkgs, true);
+
+    expect(container.querySelector('[data-testid="featured-section"]')).toBeNull();
+
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+});
+
+describe('sort-disclosure — always rendered', () => {
+  it('renders sort disclosure text in PackageList', async () => {
+    const pkgs = [makePackage('pkg-1', false)];
+    const { container, root } = await renderPackageList(pkgs, false);
+
+    const disclosure = container.querySelector('[data-testid="sort-disclosure"]');
+    expect(disclosure).not.toBeNull();
+    expect(disclosure!.textContent).toContain('No operator pays for ranking');
+
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+
+  it('sort disclosure links to /how-we-rank', async () => {
+    const pkgs = [makePackage('pkg-1', false)];
+    const { container, root } = await renderPackageList(pkgs, false);
+
+    const disclosure = container.querySelector('[data-testid="sort-disclosure"]');
+    const link = disclosure!.querySelector('a[href="/how-we-rank"]');
+    expect(link).not.toBeNull();
+
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+});

--- a/tests/ranking.test.ts
+++ b/tests/ranking.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { scorePackage, sortByScore } from '@/lib/ranking';
+import type { Package } from '@/lib/types';
+
+const basePackage: Package = {
+  id: 'pkg-1',
+  operatorId: 'op-1',
+  title: 'Test Package',
+  slug: 'test-package',
+  status: 'published',
+  pilgrimageType: 'umrah',
+  priceType: 'from',
+  pricePerPerson: 1500,
+  currency: 'GBP',
+  totalNights: 10,
+  nightsMakkah: 5,
+  nightsMadinah: 5,
+  distanceBandMakkah: 'near',
+  distanceBandMadinah: 'near',
+  roomOccupancyOptions: { single: true, double: true, triple: false, quad: false },
+  inclusions: { visa: true, flights: true, transfers: true, meals: false },
+};
+
+const recentDate = () => {
+  const d = new Date();
+  d.setDate(d.getDate() - 3);
+  return d.toISOString();
+};
+
+const staleDate = () => {
+  const d = new Date();
+  d.setDate(d.getDate() - 120);
+  return d.toISOString();
+};
+
+describe('scorePackage', () => {
+  it('returns a number between 0 and 1', () => {
+    const score = scorePackage(basePackage);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  it('returns higher score for a package updated recently vs stale', () => {
+    const fresh = { ...basePackage, updatedAt: recentDate() };
+    const stale = { ...basePackage, updatedAt: staleDate() };
+    expect(scorePackage(fresh)).toBeGreaterThan(scorePackage(stale));
+  });
+
+  it('returns higher score for a complete package vs sparse one', () => {
+    const complete: Package = {
+      ...basePackage,
+      updatedAt: recentDate(),
+      hotelMakkahName: 'Hilton Makkah',
+      hotelMadinahName: 'Hilton Madinah',
+      hotelMakkahStars: 5,
+      hotelMadinahStars: 5,
+      airline: 'Saudia',
+      departureAirport: 'LHR',
+      flightType: 'direct',
+      distanceToHaramMakkahMetres: 200,
+      distanceToHaramMadinahMetres: 300,
+      depositAmount: 500,
+      paymentPlanAvailable: true,
+      cancellationPolicy: '14 days',
+      highlights: ['Guided tours'],
+      groupType: 'small-group',
+      seasonLabel: 'Summer 2026',
+      dateWindow: { start: '2026-06-01', end: '2026-06-15' },
+    };
+    const sparse = { ...basePackage, updatedAt: recentDate() };
+    expect(scorePackage(complete)).toBeGreaterThan(scorePackage(sparse));
+  });
+
+  it('isFeatured flag does NOT affect the neutral score', () => {
+    const notFeatured = { ...basePackage, updatedAt: recentDate(), isFeatured: false };
+    const featured = { ...basePackage, updatedAt: recentDate(), isFeatured: true };
+    expect(scorePackage(featured)).toBeCloseTo(scorePackage(notFeatured), 10);
+  });
+
+  it('uses neutral 0.5 response rate when not provided', () => {
+    const pkg = { ...basePackage, updatedAt: recentDate() };
+    const withDefault = scorePackage(pkg);
+    const withExplicit = scorePackage(pkg, 0.5);
+    expect(withDefault).toBeCloseTo(withExplicit, 10);
+  });
+
+  it('higher response rate raises score', () => {
+    const pkg = { ...basePackage, updatedAt: recentDate() };
+    expect(scorePackage(pkg, 1.0)).toBeGreaterThan(scorePackage(pkg, 0.0));
+  });
+
+  it('returns 0 recency component for updatedAt missing', () => {
+    const withDate = { ...basePackage, updatedAt: recentDate() };
+    const withoutDate = { ...basePackage };
+    expect(scorePackage(withDate)).toBeGreaterThan(scorePackage(withoutDate));
+  });
+});
+
+describe('sortByScore', () => {
+  it('returns packages ordered highest score first', () => {
+    const complete: Package = {
+      ...basePackage,
+      id: 'pkg-complete',
+      slug: 'pkg-complete',
+      updatedAt: recentDate(),
+      hotelMakkahName: 'Hilton',
+      hotelMadinahName: 'Hilton Madinah',
+      hotelMakkahStars: 5,
+      hotelMadinahStars: 5,
+      airline: 'Saudia',
+      departureAirport: 'LHR',
+      flightType: 'direct',
+      distanceToHaramMakkahMetres: 200,
+      distanceToHaramMadinahMetres: 300,
+      depositAmount: 500,
+      paymentPlanAvailable: true,
+      cancellationPolicy: '14 days',
+      highlights: ['Tours'],
+      groupType: 'small-group',
+      seasonLabel: 'Summer 2026',
+      dateWindow: { start: '2026-06-01', end: '2026-06-15' },
+    };
+    const sparse: Package = { ...basePackage, id: 'pkg-sparse', slug: 'pkg-sparse' };
+
+    const sorted = sortByScore([sparse, complete]);
+    expect(sorted[0].id).toBe('pkg-complete');
+    expect(sorted[1].id).toBe('pkg-sparse');
+  });
+
+  it('does not mutate the original array', () => {
+    const pkgs = [
+      { ...basePackage, id: 'a', slug: 'a' },
+      { ...basePackage, id: 'b', slug: 'b' },
+    ];
+    const original = pkgs.map((p) => p.id);
+    sortByScore(pkgs);
+    expect(pkgs.map((p) => p.id)).toEqual(original);
+  });
+
+  it('returns empty array unchanged', () => {
+    expect(sortByScore([])).toEqual([]);
+  });
+
+  it('isFeatured does not change sort position', () => {
+    const pkg1: Package = {
+      ...basePackage,
+      id: 'featured',
+      slug: 'featured',
+      isFeatured: true,
+      updatedAt: staleDate(),
+    };
+    const pkg2: Package = {
+      ...basePackage,
+      id: 'normal',
+      slug: 'normal',
+      isFeatured: false,
+      updatedAt: recentDate(),
+    };
+    const sorted = sortByScore([pkg1, pkg2]);
+    // pkg2 is fresh — scores higher regardless of isFeatured
+    expect(sorted[0].id).toBe('normal');
+  });
+});


### PR DESCRIPTION
## Summary

- **Neutral sort** (`lib/ranking.ts`): server-side quality score — 45% data completeness, 35% price recency, 20% operator response rate. `isFeatured` has zero weight. Applied in `Repository.listPackages()` before any page receives data.
- **DMCC Act 2024 disclosure**: `NEUTRAL_SORT_DISCLOSURE` near every sort control on `/packages` and `/search/packages`, linked to `/how-we-rank`.
- **`/how-we-rank` page**: full §20 disclosure — 4 numbered criteria cards, Featured listing rules (max 2, clearly labelled "Paid placement"), §7 ATOL/CH/address verification statement verbatim. Indexed, added to sitemap + footer.
- **Featured infrastructure**: `is_featured` DB column, `FEATURE_FEATURED_SLOTS` flag (server-side only, default `false`), `FeaturedBadge` component, featured section in `PackageList` (capped at 2, above neutral list, flag-gated).
- **Tests**: 11 ranking tests (including `isFeatured` no-op proof), 10 featured-slot tests, `/how-we-rank` metadata + star-character guard in banned-phrases CI.
- **PostCSS fix**: `postcss.config.mjs` switched to object plugin syntax — compatible with both Next.js webpack and Vite/Vitest.

## Commits (8)

1. `feat(ranking)`: server-side neutral sort score
2. `feat(config)`: FEATURE_FEATURED_SLOTS flag + .env.example
3. `feat(schema)`: isFeatured in Package — schema, type, mapper
4. `feat(ui)`: FeaturedBadge + CSS for disclosure and featured section
5. `feat(ui)`: disclosure + Featured slots in PackageList and PackagesBrowse
6. `feat(transparency)`: /how-we-rank page, sitemap, footer link
7. `feat(tests)`: ranking, featured-slots, banned-phrases extensions
8. `docs`: AI_NOTES §22 + NOW.md — Q6 complete

## Test plan

- [ ] `npm run test` — 1,810/1,810 (23 files) green
- [ ] `npm run build` — 0 errors
- [ ] `npx tsc --noEmit` — 0 errors
- [ ] `/how-we-rank` renders with 4 criteria cards and Featured rules section
- [ ] Sort disclosure visible on `/packages` and `/search/packages`, links to `/how-we-rank`
- [ ] Featured section hidden (flag OFF by default); appears labelled "Paid placement" when `FEATURE_FEATURED_SLOTS=true`
- [ ] Footer includes "How we rank" link; sitemap includes `/how-we-rank`

🤖 Generated with [Claude Code](https://claude.com/claude-code)