### PR TITLE
chore: promote dev to main — partner page + footer fix

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -7,13 +7,13 @@
 
 **Stack:** Next.js 15.5 (App Router, Server Components) · React 19 · TypeScript strict · Supabase (auth/Postgres/RLS/storage, `eu-west-2`) · Prisma · Tailwind · Zustand · Vitest + Playwright.
 
-**State (2026-06-10):** Branch `dev` (1 commit behind `main` — pending structural sync PR). Tests 232/232 ✅. Build clean ✅. MockDB removed from production paths. RLS audit complete. Transactional email suite live. All domain redirects working — `pilgrimcompare.com` and `www.pilgrimcompare.com` both 301 to `pilgrimcompare.co.uk`. Supabase email confirmations ON. **WordmarkLogo** component live in Header + Footer (`components/graphics/WordmarkLogo.tsx`, Nunito ExtraBold 800, `currentColor`). PR #34 merged to `main`.
+**State (2026-06-12):** Production on `main` (PR #54 merged). Tests 1,818/1,818 ✅. Build clean ✅. Q1–Q6 quality passes complete. Full transactional email suite live (6 templates via Resend). 3 Vercel cron jobs active (nudge-operators 08:00, outcome-followup 09:00, expire-packages 02:00 UTC). CRON_SECRET auth on all cron routes. `/how-we-rank` ranking transparency page live. Sitemap + footer updated. All domain redirects working. Supabase email confirmations branded.
 
-**Remaining setup items:** None — all setup complete. Email mailboxes `support/privacy/dpo/complaints@pilgrimcompare.co.uk` live via Cloudflare Email Routing (→ Gmail). Upgrade to Google Workspace when onboarding real operators.
+**Remaining setup items:** Operational only — curl-test 3 cron endpoints with CRON_SECRET, submit test enquiry to verify email delivery, onboard first operator. Email mailboxes live via Cloudflare Email Routing (→ Gmail). Upgrade to Google Workspace when onboarding real operators.
 
 **How to verify any change (mandatory before push):**
 ```bash
-npm run test     # 232/232 must pass
+npm run test     # 1,818/1,818 must pass
 npm run build    # 0 errors
 npx tsc --noEmit # pass
 # if UI/routes changed: Playwright smoke on / , /umrah , /search/packages at 320px + 1280px

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 > **Single rolling tracker.** Any AI/dev: read this for current state. Update it after work is **done + tested + verified** (see `CLAUDE.md` rule).
 > Detailed handover lives in `AI_NOTES.md`. Cold-start brief: `HANDOFF.md`. Business: `BUSINESS.md`.
 
-**Last verified:** 2026-06-12 (Q4 mobile polish) · **Branch:** `feat/q4-mobile-polish` → PR → `dev` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
+**Last verified:** 2026-06-12 (Q1–Q6 + Prompts 5–6 production deploy) · **Branch:** `main` (PR #54 merged) · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
 
 ---
 
@@ -11,11 +11,11 @@
 
 | Check | State |
 | --- | --- |
-| `npm run test` | ✅ 238/238 pass (20 files) |
+| `npm run test` | ✅ 1,818/1,818 pass (24 files) |
 | `npm run build` | ✅ 0 errors |
 | `npx tsc --noEmit` | ✅ pass |
 | E2E `e2e/operator.spec.ts` | ✅ 30/30 pass (chromium + firefox + webkit) |
-| Lint | ✅ clean |
+| Production deploy | ✅ PR #54 → main, Vercel live 2026-06-12 |
 
 ---
 
@@ -121,14 +121,25 @@
 | Q2 — legal pages (`/terms`, `/privacy`, `/how-it-works`) | ✅ Done 2026-06-12 | — |
 | Q3 — IA/nav pass | ✅ Done 2026-06-12 | — |
 | Q4 — mobile polish 360/390/430px | ✅ Done 2026-06-12 | — |
-| Q5 — SEO metadata, JSON-LD, sitemap | Not started | Q1 done |
+| Q5 — SEO metadata, JSON-LD, sitemap | ✅ Done 2026-06-12 (PR #51) | — |
+| Q6 — ranking transparency, Featured slots | ✅ Done 2026-06-12 (PR #52) | — |
+| Prompt 5 — transactional email suite (6 templates) | ✅ Done 2026-06-12 (PR #53) | — |
+| Prompt 6 — cron jobs + outcomes endpoint | ✅ Done 2026-06-12 (PR #53) | — |
+| Plausible analytics wiring | ⏳ Not started | — |
+| `app_metadata.role` backfill (pre-2026-06-09 users) | ⏳ Not started | Needs Supabase SQL |
+| Registered office address in footer | ⏳ Not started | Awaiting virtual office |
+| Prompt 7 — Telegram operator alerts | ⏳ Not started | Prompts 5+6 live |
+| Prompt 8 — automation / operator data ingestion | ⏳ Not started | — |
+| Google Workspace upgrade | ⏳ Not started | First operator onboard |
 
 ---
 
 ## ▶️ Next actions (do in order)
 
-1. Raise PR `feat/q4-mobile-polish` → `dev` and merge after CI passes.
-2. Start Q5 — SEO pass (metadata, JSON-LD, sitemap). See `docs/PILGRIMCOMPARE_QUALITY_PROMPTS.md` → Q5.
+1. **Operational smoke test:** curl all 3 cron endpoints with `CRON_SECRET` from Vercel env vars.
+2. **First real enquiry:** submit test quote → confirm Emails 2+3 arrive via Resend logs.
+3. **Onboard first operator** via `/operator/onboarding`.
+4. Start Prompt 7 (Telegram alerts) once Prompts 5+6 confirmed working end-to-end.
 
 ---
 

--- a/app/partner/page.tsx
+++ b/app/partner/page.tsx
@@ -37,35 +37,97 @@ export default function PartnerLandingPage() {
     <>
       <JsonLdScript data={pageJsonLd} />
       <main className="min-h-screen">
-        {/* Hero */}
-        <section className="relative border-b border-[var(--border)] bg-[var(--surfaceDark)] px-4 py-20 text-center">
-          <div className="mx-auto max-w-3xl">
-            <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-[var(--yellow)]">
-              For Travel Operators
-            </p>
-            <h1 className="text-3xl font-bold leading-tight text-[var(--text)] md:text-5xl">
-              Reach Thousands of UK Muslims Planning Umrah & Hajj
-            </h1>
-            <p className="mt-5 text-lg text-[var(--textMuted)]">
-              List your verified packages on PilgrimCompare — the UK Umrah & Hajj comparison and enquiry platform.
-              No upfront fees. Transparent commission. UK-focused audience.
-            </p>
-            <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-              <Link
-                href="/operator/onboarding"
-                className="inline-flex min-h-[48px] items-center justify-center rounded-lg bg-[var(--yellow)] px-8 py-3 text-base font-semibold text-[var(--bg)] transition-opacity hover:opacity-90"
-                data-testid="partner-cta-apply"
-              >
-                Apply as an Operator
-              </Link>
-              <Link
-                href="/operators/al-hidayah-travel"
-                className="inline-flex min-h-[48px] items-center justify-center rounded-lg border border-[var(--border)] px-8 py-3 text-base font-medium text-[var(--text)] transition-colors hover:border-[var(--yellow)] hover:text-[var(--yellow)]"
-                data-testid="partner-cta-preview"
-              >
-                See Example Profile
-              </Link>
+
+        {/* ── SPLIT HERO — both paths above the fold ── */}
+        <section className="border-b border-[var(--border)] bg-[var(--surfaceDark)] px-4 py-14 md:py-20">
+          <div className="mx-auto grid max-w-6xl items-center gap-10 md:grid-cols-5 md:gap-12">
+
+            {/* Left — new operators (primary path) */}
+            <div className="md:col-span-3">
+              <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-[var(--yellow)]">
+                For Travel Operators
+              </p>
+              <h1 className="text-3xl font-bold leading-tight text-[var(--text)] md:text-4xl lg:text-5xl">
+                Reach Thousands of UK Muslims Planning Umrah &amp; Hajj
+              </h1>
+              <p className="mt-5 text-lg leading-relaxed text-[var(--textMuted)]">
+                List your verified packages on PilgrimCompare — the UK&apos;s Umrah &amp; Hajj comparison platform.
+                No upfront fees. Transparent commission. ATOL/ABTA verified operators only.
+              </p>
+              <div className="mt-8 flex flex-wrap gap-4">
+                <Link
+                  href="/operator/onboarding"
+                  className="inline-flex min-h-[48px] items-center justify-center rounded-lg bg-[var(--yellow)] px-8 py-3 text-base font-semibold text-[var(--bg)] transition-opacity hover:opacity-90"
+                  data-testid="partner-cta-apply"
+                >
+                  Apply as an Operator
+                </Link>
+                <Link
+                  href="/operators/al-hidayah-travel"
+                  className="inline-flex min-h-[48px] items-center justify-center rounded-lg border border-[var(--border)] px-6 py-3 text-base font-medium text-[var(--text)] transition-colors hover:border-[var(--yellow)] hover:text-[var(--yellow)]"
+                  data-testid="partner-cta-preview"
+                >
+                  See Example Profile
+                </Link>
+              </div>
             </div>
+
+            {/* Right — existing operators (secondary path, same visual weight as hero) */}
+            <div className="md:col-span-2">
+              <div className="rounded-xl border border-[var(--border)] bg-[var(--panel)] p-6 md:p-7">
+                {/* Label */}
+                <span className="inline-block rounded-full bg-[var(--yellow)]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-[var(--yellow)]">
+                  Already a partner?
+                </span>
+
+                <h2 className="mt-4 text-xl font-semibold text-[var(--text)]">
+                  Sign in to your operator dashboard
+                </h2>
+                <p className="mt-2 text-sm text-[var(--textMuted)]">
+                  Manage packages, view leads, track enquiries, and update your ATOL/ABTA details.
+                </p>
+
+                {/* Dashboard quick-access list */}
+                <ul className="mt-5 space-y-2.5">
+                  {[
+                    'Respond to traveller enquiries',
+                    'Add or update your packages',
+                    'View analytics &amp; conversions',
+                  ].map((item) => (
+                    <li key={item} className="flex items-center gap-2.5 text-sm text-[var(--textMuted)]">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="shrink-0 text-[var(--yellow)]" aria-hidden="true">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                      <span dangerouslySetInnerHTML={{ __html: item }} />
+                    </li>
+                  ))}
+                </ul>
+
+                <Link
+                  href="/login?redirect=/operator/dashboard"
+                  className="mt-6 inline-flex min-h-[48px] w-full items-center justify-center gap-2 rounded-lg border border-[var(--border)] px-6 py-3 text-base font-semibold text-[var(--text)] transition-colors hover:border-[var(--yellow)] hover:text-[var(--yellow)]"
+                  data-testid="partner-signin-main"
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                    <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+                    <polyline points="10 17 15 12 10 7" />
+                    <line x1="15" y1="12" x2="3" y2="12" />
+                  </svg>
+                  Sign in to Dashboard
+                </Link>
+
+                <p className="mt-3 text-center text-xs text-[var(--textMuted)]">
+                  Account issues?{' '}
+                  <a
+                    href="mailto:operators@pilgrimcompare.co.uk"
+                    className="underline underline-offset-2 hover:text-[var(--yellow)]"
+                  >
+                    Contact operator support
+                  </a>
+                </p>
+              </div>
+            </div>
+
           </div>
         </section>
 
@@ -74,7 +136,7 @@ export default function PartnerLandingPage() {
           <div className="mx-auto grid max-w-5xl gap-8 sm:grid-cols-3">
             <div className="rounded-xl border border-[var(--border)] bg-[var(--panel)] p-6 text-center">
               <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-[var(--yellow)]/10 text-[var(--yellow)]">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
                   <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
                   <circle cx="9" cy="7" r="4" />
                   <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
@@ -88,7 +150,7 @@ export default function PartnerLandingPage() {
             </div>
             <div className="rounded-xl border border-[var(--border)] bg-[var(--panel)] p-6 text-center">
               <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-[var(--yellow)]/10 text-[var(--yellow)]">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
                   <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
                 </svg>
               </div>
@@ -99,7 +161,7 @@ export default function PartnerLandingPage() {
             </div>
             <div className="rounded-xl border border-[var(--border)] bg-[var(--panel)] p-6 text-center">
               <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-[var(--yellow)]/10 text-[var(--yellow)]">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
                   <line x1="12" y1="1" x2="12" y2="23" />
                   <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
                 </svg>
@@ -112,15 +174,67 @@ export default function PartnerLandingPage() {
           </div>
         </section>
 
+        {/* Requirements */}
+        <section className="border-t border-[var(--border)] px-4 py-16">
+          <div className="mx-auto max-w-4xl">
+            <div className="mb-2 text-center">
+              <span className="inline-block rounded-full bg-[var(--yellow)]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-[var(--yellow)]">
+                Requirements to join
+              </span>
+            </div>
+            <h2 className="text-center text-2xl font-semibold text-[var(--text)]">What We Need From You</h2>
+            <p className="mx-auto mt-3 max-w-2xl text-center text-sm text-[var(--textMuted)]">
+              PilgrimCompare is a verified-only platform. Every operator must meet these requirements before going live.
+            </p>
+            <div className="mt-10 grid gap-4 sm:grid-cols-2">
+              {[
+                {
+                  title: 'ATOL or ABTA Membership',
+                  desc: 'Your financial protection number is displayed on every package listing. Travellers expect this as standard.',
+                },
+                {
+                  title: 'UK-Based Business Registration',
+                  desc: 'Companies House registered. We verify your business exists before approving your profile.',
+                },
+                {
+                  title: 'Accurate Package Pricing',
+                  desc: 'Prices must reflect real, bookable packages — not estimates. Misleading listings are removed.',
+                },
+                {
+                  title: 'Responsive to Enquiries',
+                  desc: 'Operators must respond to traveller enquiries within 48 hours or your listing ranking is affected.',
+                },
+              ].map((item) => (
+                <div key={item.title} className="flex gap-4 rounded-lg border border-[var(--border)] bg-[var(--panel)] p-5">
+                  <div className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--yellow)] text-[var(--bg)]">
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" aria-hidden="true">
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-[var(--text)]">{item.title}</h4>
+                    <p className="mt-1 text-sm text-[var(--textMuted)]">{item.desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
         {/* How it works */}
         <section className="border-t border-[var(--border)] px-4 py-16">
           <div className="mx-auto max-w-4xl">
-            <h2 className="text-center text-2xl font-semibold text-[var(--text)]">How It Works</h2>
+            <div className="mb-2 text-center">
+              <span className="inline-block rounded-full bg-[var(--yellow)]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-[var(--yellow)]">
+                New to PilgrimCompare
+              </span>
+            </div>
+            <h2 className="text-center text-2xl font-semibold text-[var(--text)]">How to Get Listed</h2>
             <div className="mt-10 grid gap-6 sm:grid-cols-3">
               {[
                 { step: '1', title: 'Apply', desc: 'Complete the registration form with your company details, ATOL/ABTA numbers, and package offerings.' },
                 { step: '2', title: 'Get Verified', desc: 'Our team reviews your application within 1–2 business days. We verify your financial protection status.' },
-                { step: '3', title: 'Start receiving enquiries', desc: 'Once approved, your packages appear in search results and travellers can send enquiries directly to you.' },
+                { step: '3', title: 'Start Receiving Enquiries', desc: 'Once approved, your packages appear in search results and travellers can send enquiries directly to you.' },
               ].map((item) => (
                 <div key={item.step} className="relative rounded-lg border border-[var(--border)] bg-[var(--panel)] p-5">
                   <span className="absolute -top-3 left-4 inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--yellow)] text-xs font-bold text-[var(--bg)]">
@@ -131,10 +245,19 @@ export default function PartnerLandingPage() {
                 </div>
               ))}
             </div>
+            <div className="mt-10 text-center">
+              <Link
+                href="/operator/onboarding"
+                className="inline-flex min-h-[48px] items-center justify-center rounded-lg bg-[var(--yellow)] px-10 py-3 text-base font-semibold text-[var(--bg)] transition-opacity hover:opacity-90"
+                data-testid="partner-cta-how-it-works"
+              >
+                Apply as an Operator
+              </Link>
+            </div>
           </div>
         </section>
 
-        {/* Trust */}
+        {/* Trust / compliance */}
         <section className="border-t border-[var(--border)] px-4 py-16">
           <div className="mx-auto max-w-3xl text-center">
             <h2 className="text-2xl font-semibold text-[var(--text)]">Built for UK Compliance</h2>
@@ -160,8 +283,19 @@ export default function PartnerLandingPage() {
             >
               Apply as an Operator
             </Link>
+            <p className="mt-4 text-sm text-[var(--textMuted)]">
+              Already a partner?{' '}
+              <Link
+                href="/login?redirect=/operator/dashboard"
+                className="font-medium text-[var(--yellow)] underline-offset-2 hover:underline"
+                data-testid="partner-signin-footer"
+              >
+                Sign in to your dashboard
+              </Link>
+            </p>
           </div>
         </section>
+
       </main>
     </>
   )

--- a/components/graphics/WordmarkLogo.tsx
+++ b/components/graphics/WordmarkLogo.tsx
@@ -17,16 +17,13 @@ export function WordmarkLogo({
     <svg
       viewBox="0 0 264 40"
       height={height}
-      width="auto"
+      width={Math.round(height * 264 / 40)}
       xmlns="http://www.w3.org/2000/svg"
       aria-label="PilgrimCompare"
       role="img"
       className={className}
       style={{ display: 'block', fill: color, ...style }}
     >
-      <defs>
-        <style>{`@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@800&display=swap');`}</style>
-      </defs>
       <text
         x="0"
         y="31"

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -75,14 +75,14 @@ function Section({
     <div
       className={`border-t border-[var(--borderSubtle)] py-3 md:border-0 md:py-0 ${
         isLast ? 'border-b md:border-b-0' : ''
-      } ${isFirst ? '' : ''}`}
+      }`}
     >
       <button
         type="button"
         onClick={() => setOpen(o => !o)}
         aria-expanded={expanded}
         aria-controls={contentId}
-        className="flex w-full items-center justify-between text-left text-sm font-semibold text-[var(--text)] md:cursor-default"
+        className="flex w-full items-center justify-between text-left text-sm font-semibold text-[var(--text)] md:cursor-default md:pointer-events-none"
       >
         <span>{title}</span>
         <Chevron open={expanded} />
@@ -98,34 +98,51 @@ function Section({
   );
 }
 
+function BrandBlock() {
+  return (
+    <>
+      <Link
+        href="/"
+        className="flex shrink-0 items-center gap-2"
+        aria-label="PilgrimCompare - Go to homepage"
+      >
+        <Logo size={26} />
+        <WordmarkLogo height={24} style={{ color: 'var(--wordmark-color, var(--yellow, #FFD31D))' }} />
+      </Link>
+      <p className="text-xs leading-relaxed text-[var(--textMuted)]">
+        PilgrimCompare is a UK comparison and enquiry service for Umrah travel packages. We list
+        packages from independent, verified UK travel operators so you can compare them side by
+        side and send enquiries directly. We are not a travel agent, tour operator, or organiser.
+        We do not sell travel, take bookings, or handle payments. Your booking, contract, and
+        payment are always with the operator you choose.
+      </p>
+    </>
+  );
+}
+
 export function Footer({ cities = [] }: { cities?: string[] }) {
   const currentYear = new Date().getFullYear();
   const isDesktop = useIsDesktop();
 
   return (
     <footer className="border-t border-[var(--borderSubtle)] bg-[var(--surfaceDark)]" role="contentinfo">
-      <div className="mx-auto max-w-6xl px-5 py-8 md:px-6 md:py-10">
-        {/* Brand block — left-aligned across all breakpoints */}
-        <div className="mb-6 flex flex-col gap-2 md:mb-8 md:flex-row md:items-start md:gap-6">
-          <Link
-            href="/"
-            className="flex shrink-0 items-center gap-2"
-            aria-label="PilgrimCompare - Go to homepage"
-          >
-            <Logo size={26} />
-            <WordmarkLogo height={24} style={{ color: 'var(--wordmark-color, var(--yellow, #FFD31D))' }} />
-          </Link>
-          <p className="text-xs leading-relaxed text-[var(--textMuted)] md:max-w-sm">
-            PilgrimCompare is a UK comparison and enquiry service for Umrah travel packages. We list
-            packages from independent, verified UK travel operators so you can compare them side by
-            side and send enquiries directly. We are not a travel agent, tour operator, or organiser.
-            We do not sell travel, take bookings, or handle payments. Your booking, contract, and
-            payment are always with the operator you choose.
-          </p>
+      <div className="mx-auto max-w-6xl px-5 py-8 md:px-8 md:py-12">
+
+        {/* Mobile brand block — shown only on mobile, above the accordions */}
+        <div className="mb-6 flex flex-col gap-3 md:hidden">
+          <BrandBlock />
         </div>
 
-        {/* Sections — accordions on mobile, open grid on desktop */}
-        <div className="grid gap-1 md:grid-cols-3 md:gap-8">
+        {/* Main grid:
+            Mobile  — single-column stacked accordions
+            Desktop — 4-col: [brand 2fr] [contact 1fr] [legal 1fr] [platform 1fr] */}
+        <div className="grid gap-1 md:grid-cols-[2fr_1fr_1fr_1fr] md:gap-10 md:items-start">
+
+          {/* Brand col — desktop only */}
+          <div className="hidden md:flex md:flex-col md:gap-4">
+            <BrandBlock />
+          </div>
+
           <Section title="Contact" defaultOpen isFirst forceOpen={isDesktop}>
             <address className="text-xs not-italic leading-relaxed text-[var(--textMuted)]">
               United Kingdom<br />
@@ -192,8 +209,8 @@ export function Footer({ cities = [] }: { cities?: string[] }) {
           </Section>
         </div>
 
-        {/* Disclaimer — single condensed block */}
-        <div className="mt-6 border-t border-[var(--borderSubtle)] pt-5 md:mt-8 md:pt-6">
+        {/* Disclaimer */}
+        <div className="mt-6 border-t border-[var(--borderSubtle)] pt-5 md:mt-10 md:pt-6">
           <p className="text-xs leading-relaxed text-[var(--textMuted)]">
             <strong className="text-[var(--text)]">Important:</strong> PilgrimCompare is a comparison
             platform only. We do not organise, sell, or fulfil travel packages and do not collect, hold,
@@ -221,16 +238,17 @@ export function Footer({ cities = [] }: { cities?: string[] }) {
         </div>
 
         {/* Copyright */}
-        <div className="mt-5 flex flex-col gap-1 border-t border-[var(--borderSubtle)] pt-4 justify-center text-xs text-[var(--textMuted)] md:justify-between md:flex-row md:items-center md:gap-2">
-          <p className="text-center md:text-left">&copy; {currentYear} PilgrimCompare. All rights reserved.</p>
-          <p className="text-center md:text-left">Governed by the laws of England and Wales.</p>
+        <div className="mt-5 border-t border-[var(--borderSubtle)] pt-4 text-xs text-[var(--textMuted)]">
+          {/* Mobile: stacked centered | Desktop: single left-anchored line */}
+          <p className="text-center md:text-left">
+            <span>&copy; {currentYear} PilgrimCompare. All rights reserved.</span>
+            <span className="hidden md:inline"> &middot; </span>
+            <span className="block md:inline">Governed by the laws of England and Wales.</span>
+          </p>
         </div>
 
-        {/* Legal entity disclosure — Companies Act 2006 §82
-            Registered office address intentionally omitted while founder
-            transitions to a non-residential registered office. See AI_NOTES §14.
-            TODO: add registeredOffice line once LEGAL_ENTITY_BLOCK.registeredOffice is set. */}
-        <p className="mt-3 text-center text-[11px] leading-relaxed text-[var(--textMuted)]">
+        {/* Legal entity disclosure — Companies Act 2006 §82 */}
+        <p className="mt-3 text-center text-[11px] leading-relaxed text-[var(--textMuted)] md:text-left">
           {LEGAL_ENTITY_BLOCK.tradingName} is a trading name of{' '}
           <span className="text-[var(--text)]">{LEGAL_ENTITY_BLOCK.companyName}</span>, registered
           in {LEGAL_ENTITY_BLOCK.registeredCountry} (company no.{' '}


### PR DESCRIPTION
## Summary

Promotes 3 commits from dev to main:

- **#58** `feat(partner)` — dual-audience partner page with split-hero, operator sign-in above the fold
- **#57** `fix(footer)` — desktop layout, SVG/CSP fixes, bottom bar alignment
- **#55** `docs` — STATUS.md and HANDOFF.md sync to Q1–Q6 + Prompts 5–6 state

## Test plan

- [ ] CI green on this PR
- [ ] Vercel preview passes
- [ ] `/partner` renders split-hero on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)