### PR TITLE
fix(data-integrity): show "Not provided" for missing operator facts (cards, JSON-LD, quote prefill)

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -275,6 +275,10 @@ Next.js App Router UI
 | `KT-` reference prefix | Existing DB records use this. Rename only post-launch after migration. `/terms` copy references `KT-XXXXX` — update when prefix changes. |
 | Docs consistency | Some docs contain stale historical status. Update when touched; do not regress implementation to match stale docs. |
 
+### Future features — flagged, NOT approved for build
+
+- **Hotel data enrichment** logged as a FUTURE feature, NOT approved for build — must be scoped against standards §9 before any work (three distinct states: operator-stated / verified-with-source / Not provided; never silent-fill; operator can correct; disclose to users). The "Not provided" baseline from this fix is its prerequisite. Knowledge base Section 8 + 15 updated.
+
 ---
 
 ## 9. Infrastructure Reference
@@ -1136,3 +1140,30 @@ Rebuilt the homepage (`app/page.tsx`) from Hero-only (3 CTA cards + a routes nav
 
 ### Next step
 Founder review of the redesign in both themes, then open PR `feature/homepage-redesign` → `dev`. Update `STATUS.md`/`HANDOFF.md` on the same branch before the PR.
+
+---
+
+## 27. Data Integrity — "Not provided" for missing operator facts — 2026-06-13
+
+**Branch:** `fix/data-integrity-not-provided` (off `dev`).
+**Tests:** 1,825/1,825 pass (26 files, +7 new) · `tsc --noEmit` clean · `npm run build` 0 errors.
+
+### Why
+A read-only audit found user-facing surfaces that **inferred** operator-supplied fields when missing, violating the hard rule *missing = "Not provided", never inferred* (`AGENTS.md`; standards §9/§12). Fixed the live fabrications; documented the rest as scope boundaries.
+
+### What changed (one concern per commit)
+1. **Package cards** (`components/search/search-utils.ts`, `PackageCard.tsx`, `packages.module.css`, `PackageList.tsx`):
+   - `SearchHotel.name`/`rating` are now `string | null` / `number | null`. `toSearchDisplay` passes `hotelMakkah/MadinahName ?? null` and `hotelMakkah/MadinahStars ?? null` — **was** `?? pkg.title` (hotel name fell back to the package title) and `?? 4` (stars defaulted to 4).
+   - Card renders **"Not provided"** (italic, muted, new `.notProvided` class) for a null name or rating instead of fabricated stars / a borrowed title.
+   - Rating-sort treats missing as 0 **for ordering only** (sorts to the bottom; the card still shows "Not provided"). Compare-toggle aria-label switched from `hotel.name` → operator company name (null-safe).
+2. **Package JSON-LD** (`lib/seo/json-ld.ts`): `packageJsonLd` defaulted missing stars to `0` and emitted "0★" in the Product description. Now the hotels sentence is built only from stars that exist, and a `Makkah/Madinah hotel rating` PropertyValue is emitted **per city only when present**. Missing = property **absent** (not null, not 0, not empty) — verified by emitting the JSON-LD for a stars-less package: `additionalProperty` carries only Pilgrimage type + nights, no rating property; description has no `★`.
+3. **Quote prefill** (`lib/quote-prefill.ts`): `createQuotePrefillUrl` set `hotelStars` to `?? 4`, pre-seeding the enquiry with a fabricated preference. Now set **only** when a real rating exists, otherwise omitted.
+
+### Explicitly out of scope (deliberate)
+- `quote-prefill` inclusions `?? true` / `distancePreference` — seed the **customer's own enquiry-form preferences**, not displayed operator facts. Belongs with the operator-form task.
+- `PackageDetail.tsx` `?★` — already honest (shows unknown, not a fabricated number). Left as-is.
+- JSON-LD nights/price `??` defaults — **dead code** (`totalNights`/`nightsMakkah`/`nightsMadinah`/`pricePerPerson` are required `number` in `lib/types.ts`, so the fallbacks never fire). Left untouched to keep the diff tight.
+- Operator-form **entry defaults** (4-star / medium distance / small-group pre-selected in the wizard) — upstream data-quality risk (a skipped field can save a default as if confirmed). Separate task.
+
+### Future feature — flagged, NOT approved
+- **Hotel data enrichment** logged in §8 (Open Risks → Future features): must be scoped against standards §9 before any work (three distinct states: operator-stated / verified-with-source / Not provided; never silent-fill; operator can correct; disclose to users). The "Not provided" baseline from **this** fix is its prerequisite.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -7,13 +7,13 @@
 
 **Stack:** Next.js 15.5 (App Router, Server Components) · React 19 · TypeScript strict · Supabase (auth/Postgres/RLS/storage, `eu-west-2`) · Prisma · Tailwind · Zustand · Vitest + Playwright.
 
-**State (2026-06-12):** Production on `main` (PR #54 merged). Tests 1,818/1,818 ✅. Build clean ✅. Q1–Q6 quality passes complete. Full transactional email suite live (6 templates via Resend). 3 Vercel cron jobs active (nudge-operators 08:00, outcome-followup 09:00, expire-packages 02:00 UTC). CRON_SECRET auth on all cron routes. `/how-we-rank` ranking transparency page live. Sitemap + footer updated. All domain redirects working. Supabase email confirmations branded.
+**State (2026-06-13):** Production on `main` (PR #54). Tests 1,825/1,825 ✅. Build clean ✅. Light theme + search redesign + pagination on `main`. Homepage redesign (audience routing + live compare preview) merged to `dev` (PR #63). Data-integrity "Not provided" fix on `fix/data-integrity-not-provided` (PR → dev pending) — package cards, package JSON-LD, and quote prefill no longer infer missing hotel name/stars. Q1–Q6 quality passes complete. Full transactional email suite live (6 templates via Resend). 3 Vercel cron jobs active. `/how-we-rank` ranking transparency page live.
 
 **Remaining setup items:** Operational only — curl-test 3 cron endpoints with CRON_SECRET, submit test enquiry to verify email delivery, onboard first operator. Email mailboxes live via Cloudflare Email Routing (→ Gmail). Upgrade to Google Workspace when onboarding real operators.
 
 **How to verify any change (mandatory before push):**
 ```bash
-npm run test     # 1,818/1,818 must pass
+npm run test     # 1,825/1,825 must pass
 npm run build    # 0 errors
 npx tsc --noEmit # pass
 # if UI/routes changed: Playwright smoke on / , /umrah , /search/packages at 320px + 1280px

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,15 +3,15 @@
 > **Single rolling tracker.** Any AI/dev: read this for current state. Update it after work is **done + tested + verified** (see `CLAUDE.md` rule).
 > Detailed handover lives in `AI_NOTES.md`. Cold-start brief: `HANDOFF.md`. Business: `BUSINESS.md`.
 
-**Last verified:** 2026-06-13 (light theme + search redesign + pagination — merged to dev + main) · **Branch:** `main` (clean) · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
+**Last verified:** 2026-06-13 (data-integrity "Not provided" fix) · **Branch:** `fix/data-integrity-not-provided` (PR → dev pending) · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
 
 ---
 
-## Health (verified 2026-06-12)
+## Health (verified 2026-06-13)
 
 | Check | State |
 | --- | --- |
-| `npm run test` | ✅ 1,818/1,818 pass (24 files) |
+| `npm run test` | ✅ 1,825/1,825 pass (26 files) |
 | `npm run build` | ✅ 0 errors |
 | `npx tsc --noEmit` | ✅ pass |
 | E2E `e2e/operator.spec.ts` | ✅ 30/30 pass (chromium + firefox + webkit) |
@@ -129,6 +129,8 @@
 | Light theme (Madinah) — 7-step implementation | ✅ Done 2026-06-13 (merged to dev + main) | — |
 | Search header redesign (world-class) | ✅ Done 2026-06-13 (merged to dev + main) | — |
 | Search results pagination (5/page) | ✅ Done 2026-06-13 (merged to dev + main) | — |
+| Homepage redesign — audience routing + live compare preview | ✅ Done 2026-06-13 (PR #63 → dev) | — |
+| Data integrity — "Not provided" for missing hotel name/stars (cards, JSON-LD, quote prefill) | ✅ Done 2026-06-13 (PR → dev pending, see AI_NOTES §27) | — |
 | Plausible analytics wiring | ⏳ Not started | — |
 | `app_metadata.role` backfill (pre-2026-06-09 users) | ⏳ Not started | Needs Supabase SQL |
 | Registered office address in footer | ⏳ Not started | Awaiting virtual office |

--- a/components/search/PackageCard.tsx
+++ b/components/search/PackageCard.tsx
@@ -57,21 +57,32 @@ const PackageCard: React.FC<PackageCardProps> = ({
     [pkg.currency, pkg.price, regionSettings]
   )
 
-  const renderStars = (rating: number, label: string) => (
-    <span className={styles.hotelRating} role="img" aria-label={`${rating} out of 5 stars, ${label}`}>
-      {[1, 2, 3, 4, 5].map((i) => (
-        <svg
-          key={i}
-          className={i <= rating ? styles.star : styles.starEmpty}
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-        </svg>
-      ))}
-      <span className={styles.ratingText}>{rating}/5</span>
-    </span>
-  )
+  const renderStars = (rating: number | null, label: string) => {
+    // Operator has not supplied a star rating — state that honestly rather than
+    // rendering a fabricated default. (Data-integrity rule: missing = Not provided.)
+    if (rating == null) {
+      return (
+        <span className={styles.notProvided} aria-label={`Hotel rating not provided, ${label}`}>
+          Not provided
+        </span>
+      )
+    }
+    return (
+      <span className={styles.hotelRating} role="img" aria-label={`${rating} out of 5 stars, ${label}`}>
+        {[1, 2, 3, 4, 5].map((i) => (
+          <svg
+            key={i}
+            className={i <= rating ? styles.star : styles.starEmpty}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+          </svg>
+        ))}
+        <span className={styles.ratingText}>{rating}/5</span>
+      </span>
+    )
+  }
 
   const totalNights = (nightsMakkah ?? 0) + (nightsMadinah ?? 0)
   const nightsLabel = totalNights > 0
@@ -104,7 +115,9 @@ const PackageCard: React.FC<PackageCardProps> = ({
       />
       <div className={styles.hotelInfo}>
         <span className={styles.hotelLocation}>{hotel.location}</span>
-        <span className={styles.hotelName}>{hotel.name}</span>
+        <span className={hotel.name ? styles.hotelName : styles.notProvided}>
+          {hotel.name ?? 'Not provided'}
+        </span>
         <div className={styles.hotelMeta}>
           {renderStars(hotel.rating, hotel.location)}
           {!isPlaceholder(hotel.distance) && (
@@ -224,7 +237,7 @@ const PackageCard: React.FC<PackageCardProps> = ({
             disabled={compareLocked}
             data-testid={`package-compare-toggle-${pkg.id}`}
             onChange={() => onToggleCompare(pkg.id)}
-            aria-label={isCompareSelected ? `Remove ${pkg.makkahHotel.name} package from comparison` : `Select ${pkg.makkahHotel.name} package to compare`}
+            aria-label={isCompareSelected ? `Remove ${operator?.companyName ?? 'this'} package from comparison` : `Select ${operator?.companyName ?? 'this'} package to compare`}
           />
           <span className={styles.compareBox} aria-hidden="true">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" aria-hidden="true">

--- a/components/search/PackageList.tsx
+++ b/components/search/PackageList.tsx
@@ -194,8 +194,13 @@ const PackageList: React.FC<PackageListProps> = ({
         return sorted.sort((a, b) => a.price - b.price);
       case 'price-desc':
         return sorted.sort((a, b) => b.price - a.price);
-      case 'rating':
-        return sorted.sort((a, b) => (b.makkahHotel.rating + b.madinaHotel.rating) - (a.makkahHotel.rating + a.madinaHotel.rating));
+      case 'rating': {
+        // Missing ratings are not inferred — they sort to the bottom (treated as
+        // 0 for ordering only; the card still shows "Not provided").
+        const ratingScore = (p: typeof sorted[number]) =>
+          (p.makkahHotel.rating ?? 0) + (p.madinaHotel.rating ?? 0);
+        return sorted.sort((a, b) => ratingScore(b) - ratingScore(a));
+      }
       case 'distance':
         // Prefer near hotels (simple heuristic)
         return sorted.sort((a, b) => {

--- a/components/search/packages.module.css
+++ b/components/search/packages.module.css
@@ -487,6 +487,13 @@
   color: var(--textMuted);
 }
 
+/* Honest empty state for operator data the card cannot infer (name/rating). */
+.notProvided {
+  font-size: 0.75rem;
+  font-style: italic;
+  color: var(--textMuted);
+}
+
 .hotelDistance svg {
   color: var(--primary);
 }

--- a/components/search/search-utils.ts
+++ b/components/search/search-utils.ts
@@ -13,9 +13,11 @@ export interface SearchFlightSegment {
 }
 
 export interface SearchHotel {
-  name: string;
+  // null = the operator has not supplied this. The card shows "Not provided"
+  // rather than inferring a name or a star rating.
+  name: string | null;
   location: string;
-  rating: number;
+  rating: number | null;
   distance: string;
   image: string;
 }
@@ -142,16 +144,18 @@ export function toSearchDisplay(pkg: CataloguePackage): SearchPackageDisplay {
     departure: { date: pkg.dateWindow?.start ?? 'TBC', duration: '-', route: departureRoute },
     return: { date: pkg.dateWindow?.end ?? 'TBC', duration: '-', route: departureRoute },
     makkahHotel: {
-      name: pkg.hotelMakkahName ?? pkg.title,
+      // Operator-supplied facts only — missing name/stars stay null (shown as
+      // "Not provided"), never inferred from the package title or a default.
+      name: pkg.hotelMakkahName ?? null,
       location: 'Makkah',
-      rating: pkg.hotelMakkahStars ?? 4,
+      rating: pkg.hotelMakkahStars ?? null,
       distance: dist(pkg.distanceBandMakkah),
       image: pkg.images?.[0] ?? PLACEHOLDER_IMAGE,
     },
     madinaHotel: {
-      name: pkg.hotelMadinahName ?? pkg.title,
+      name: pkg.hotelMadinahName ?? null,
       location: 'Madinah',
-      rating: pkg.hotelMadinahStars ?? 4,
+      rating: pkg.hotelMadinahStars ?? null,
       distance: dist(pkg.distanceBandMadinah),
       image: pkg.images?.[0] ?? PLACEHOLDER_IMAGE,
     },

--- a/lib/quote-prefill.ts
+++ b/lib/quote-prefill.ts
@@ -44,8 +44,10 @@ export const createQuotePrefillUrl = (pkg: Package) => {
   params.set('nightsMakkah', String(pkg.nightsMakkah))
   params.set('nightsMadinah', String(pkg.nightsMadinah))
 
-  const hotelStars = pkg.hotelMakkahStars ?? pkg.hotelMadinahStars ?? 4
-  params.set('hotelStars', String(hotelStars))
+  // Seed the star preference only from a real operator-supplied rating. When
+  // neither hotel has stars, leave it unset rather than fabricating a default.
+  const hotelStars = pkg.hotelMakkahStars ?? pkg.hotelMadinahStars
+  if (typeof hotelStars === 'number') params.set('hotelStars', String(hotelStars))
   params.set('distancePreference', normalizeDistance(pkg.distanceBandMakkah))
 
   params.set('visa', String(pkg.inclusions?.visa ?? true))

--- a/lib/seo/json-ld.ts
+++ b/lib/seo/json-ld.ts
@@ -24,8 +24,15 @@ const compact = <T>(items: Array<T | undefined | false | null>): T[] => items.fi
 export function packageJsonLd(pkg: Package, operatorName: string): Record<string, unknown> {
   const nightsMakkah = pkg.nightsMakkah ?? Math.ceil((pkg.totalNights ?? 0) / 2);
   const nightsMadinah = pkg.nightsMadinah ?? Math.floor((pkg.totalNights ?? 0) / 2);
-  const hotelMakkahStars = pkg.hotelMakkahStars ?? 0;
-  const hotelMadinahStars = pkg.hotelMadinahStars ?? 0;
+  // Operator-supplied star ratings only. When absent they are omitted from the
+  // schema entirely — never emitted as 0 or a default (data-integrity rule).
+  const hasMakkahStars = typeof pkg.hotelMakkahStars === 'number';
+  const hasMadinahStars = typeof pkg.hotelMadinahStars === 'number';
+  const hotelStarsParts = [
+    hasMakkahStars ? `${pkg.hotelMakkahStars}★ Makkah` : null,
+    hasMadinahStars ? `${pkg.hotelMadinahStars}★ Madinah` : null,
+  ].filter(Boolean);
+  const hotelDescription = hotelStarsParts.length ? ` Hotels: ${hotelStarsParts.join(', ')}.` : '';
   const startDate = pkg.dateWindow?.start;
   const endDate = pkg.dateWindow?.end;
   const packageUrl = `${BASE_URL}/packages/${pkg.slug}`;
@@ -35,7 +42,7 @@ export function packageJsonLd(pkg: Package, operatorName: string): Record<string
     '@type': 'Product',
     '@id': `${packageUrl}#product`,
     name: pkg.title,
-    description: `${pkg.pilgrimageType} package – ${pkg.totalNights} nights (${nightsMakkah} Makkah, ${nightsMadinah} Madinah). Hotels: ${hotelMakkahStars}★ Makkah, ${hotelMadinahStars}★ Madinah.`,
+    description: `${pkg.pilgrimageType} package – ${pkg.totalNights} nights (${nightsMakkah} Makkah, ${nightsMadinah} Madinah).${hotelDescription}`,
     sku: pkg.id,
     image: compact([...(pkg.images ?? [])]),
     brand: {
@@ -73,6 +80,20 @@ export function packageJsonLd(pkg: Package, operatorName: string): Record<string
         name: 'Madinah nights',
         value: String(nightsMadinah),
       },
+      hasMakkahStars
+        ? {
+            '@type': 'PropertyValue',
+            name: 'Makkah hotel rating',
+            value: String(pkg.hotelMakkahStars),
+          }
+        : undefined,
+      hasMadinahStars
+        ? {
+            '@type': 'PropertyValue',
+            name: 'Madinah hotel rating',
+            value: String(pkg.hotelMadinahStars),
+          }
+        : undefined,
       pkg.departureAirport
         ? {
             '@type': 'PropertyValue',

--- a/tests/quote-prefill.test.ts
+++ b/tests/quote-prefill.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { createQuotePrefillUrl } from '@/lib/quote-prefill';
+import type { Package } from '@/lib/types';
+
+const basePackage: Package = {
+  id: 'pkg-1',
+  operatorId: 'op1',
+  title: 'Umrah package',
+  slug: 'umrah-package',
+  status: 'published',
+  pilgrimageType: 'umrah',
+  seasonLabel: 'Flexible',
+  priceType: 'from',
+  pricePerPerson: 1200,
+  currency: 'GBP',
+  totalNights: 10,
+  nightsMakkah: 5,
+  nightsMadinah: 5,
+  distanceBandMakkah: 'near',
+  distanceBandMadinah: 'near',
+  roomOccupancyOptions: { single: true, double: true, triple: true, quad: true },
+  inclusions: { visa: true, flights: true, transfers: true, meals: false },
+};
+
+const paramsOf = (pkg: Package) => new URLSearchParams(createQuotePrefillUrl(pkg).split('?')[1]);
+
+describe('createQuotePrefillUrl — data integrity (no fabricated star preference)', () => {
+  it('omits hotelStars when the operator supplied no rating', () => {
+    const params = paramsOf(basePackage);
+    expect(params.has('hotelStars')).toBe(false);
+  });
+
+  it('seeds hotelStars from the operator-supplied rating when present', () => {
+    expect(paramsOf({ ...basePackage, hotelMakkahStars: 5 }).get('hotelStars')).toBe('5');
+    expect(paramsOf({ ...basePackage, hotelMadinahStars: 3 }).get('hotelStars')).toBe('3');
+  });
+});

--- a/tests/search-utils.test.ts
+++ b/tests/search-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { filterByParams } from '@/components/search/search-utils';
+import { filterByParams, toSearchDisplay } from '@/components/search/search-utils';
 import type { Package } from '@/lib/types';
 
 const basePackage: Package = {
@@ -62,5 +62,33 @@ describe('filterByParams', () => {
       'lhr-package',
       'lgw-package',
     ]);
+  });
+});
+
+describe('toSearchDisplay — data integrity (missing = Not provided)', () => {
+  it('returns null hotel name and rating when the operator has not supplied them', () => {
+    const display = toSearchDisplay(basePackage);
+
+    // No inferred star rating (was previously ?? 4) and no title-as-hotel-name.
+    expect(display.makkahHotel.rating).toBeNull();
+    expect(display.madinaHotel.rating).toBeNull();
+    expect(display.makkahHotel.name).toBeNull();
+    expect(display.madinaHotel.name).toBeNull();
+    expect(display.makkahHotel.name).not.toBe(basePackage.title);
+  });
+
+  it('passes through operator-supplied hotel name and rating unchanged', () => {
+    const display = toSearchDisplay({
+      ...basePackage,
+      hotelMakkahName: 'Hilton Makkah',
+      hotelMakkahStars: 5,
+      hotelMadinahName: 'Pullman Madinah',
+      hotelMadinahStars: 4,
+    });
+
+    expect(display.makkahHotel.name).toBe('Hilton Makkah');
+    expect(display.makkahHotel.rating).toBe(5);
+    expect(display.madinaHotel.name).toBe('Pullman Madinah');
+    expect(display.madinaHotel.rating).toBe(4);
   });
 });

--- a/tests/seo-json-ld.test.ts
+++ b/tests/seo-json-ld.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { packageJsonLd } from '@/lib/seo/json-ld';
+import type { Package } from '@/lib/types';
+
+const basePackage: Package = {
+  id: 'pkg-1',
+  operatorId: 'op1',
+  title: 'Umrah package',
+  slug: 'umrah-package',
+  status: 'published',
+  pilgrimageType: 'umrah',
+  seasonLabel: 'Flexible',
+  priceType: 'from',
+  pricePerPerson: 1200,
+  currency: 'GBP',
+  totalNights: 10,
+  nightsMakkah: 5,
+  nightsMadinah: 5,
+  distanceBandMakkah: 'near',
+  distanceBandMadinah: 'near',
+  roomOccupancyOptions: { single: true, double: true, triple: true, quad: true },
+  inclusions: { visa: true, flights: true, transfers: true, meals: false },
+};
+
+const ratingProps = (jsonLd: Record<string, unknown>) =>
+  (jsonLd.additionalProperty as Array<{ name: string }>).filter((p) => p.name.includes('hotel rating'));
+
+describe('packageJsonLd — data integrity (missing stars omitted, never 0)', () => {
+  it('omits the hotel rating property entirely when stars are absent', () => {
+    const jsonLd = packageJsonLd(basePackage, 'Test Operator');
+
+    // No rating PropertyValue at all — not null, not 0, not empty.
+    expect(ratingProps(jsonLd)).toHaveLength(0);
+    // And no fabricated "★" claim in the human-readable description.
+    expect(String(jsonLd.description)).not.toContain('★');
+    expect(String(jsonLd.description)).not.toContain('0★');
+  });
+
+  it('emits the rating property only for the city whose stars exist', () => {
+    const jsonLd = packageJsonLd({ ...basePackage, hotelMakkahStars: 5 }, 'Test Operator');
+    const props = ratingProps(jsonLd);
+
+    expect(props).toEqual([{ '@type': 'PropertyValue', name: 'Makkah hotel rating', value: '5' }]);
+    expect(String(jsonLd.description)).toContain('5★ Makkah');
+    expect(String(jsonLd.description)).not.toContain('Madinah.');
+  });
+
+  it('emits both rating properties when both cities have stars', () => {
+    const jsonLd = packageJsonLd(
+      { ...basePackage, hotelMakkahStars: 5, hotelMadinahStars: 4 },
+      'Test Operator'
+    );
+
+    expect(ratingProps(jsonLd)).toEqual([
+      { '@type': 'PropertyValue', name: 'Makkah hotel rating', value: '5' },
+      { '@type': 'PropertyValue', name: 'Madinah hotel rating', value: '4' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Why

A read-only audit found user-facing surfaces that **inferred** operator-supplied fields when missing, violating the hard rule *missing = "Not provided", never inferred* (`AGENTS.md`; standards §9/§12). This fixes the live fabrications and documents the rest as explicit scope boundaries.

## Changes (one concern per commit)

1. **Package cards** — `SearchHotel.name`/`rating` are now nullable. `toSearchDisplay` passes `?? null` instead of `?? pkg.title` (hotel name → package title) and `?? 4` (stars → default 4). The card renders **"Not provided"** for a null name/rating instead of a borrowed title or fabricated stars. Rating-sort treats missing as lowest (ordering only); compare aria-label switched to the operator name (null-safe).
2. **Package JSON-LD** — `packageJsonLd` defaulted missing stars to `0` and emitted "0★" in the Product description. Star ratings are now included **only when supplied**: the hotels sentence drops when absent, and a `Makkah/Madinah hotel rating` PropertyValue is emitted per city only when present. **Missing = property absent (not null, not 0, not empty).**
3. **Quote prefill** — `createQuotePrefillUrl` set `hotelStars` to `?? 4`, pre-seeding the enquiry with a fabricated preference. Now set only when a real rating exists, else omitted.

## Validation of the JSON-LD requirement

Emitted JSON-LD for a package with **no stars**:
- `description`: `"umrah package – 10 nights (5 Makkah, 5 Madinah)."` — no `★`, no `0★`.
- `additionalProperty`: only Pilgrimage type + Makkah/Madinah nights — **no hotel-rating property at all**.

Covered by `tests/seo-json-ld.test.ts` (absent when missing, present per-city when supplied).

## Explicitly out of scope (deliberate, documented in AI_NOTES §27)

- `quote-prefill` inclusions `?? true` / `distancePreference` — seed the customer's own enquiry-form preferences, not displayed operator facts. Belongs with the operator-form task.
- `PackageDetail.tsx` `?★` — already honest (unknown, not fabricated).
- JSON-LD nights/price `??` defaults — dead code (those fields are required `number` in `lib/types.ts`).
- Operator-form **entry defaults** (4-star / medium / small-group) — upstream data-quality, separate task.

Also flags **hotel data enrichment** as a FUTURE feature, NOT approved for build (AI_NOTES §8) — must be scoped against standards §9 first. The "Not provided" baseline here is its prerequisite.

## Validation
- `npx tsc --noEmit` — pass
- `npm run test` — 1,825/1,825 (26 files, +7 new: search-utils, seo-json-ld, quote-prefill)
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)