### PR TITLE
fix(operator): no silent defaults for skipped hotel stars, distance, group type

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1167,3 +1167,42 @@ A read-only audit found user-facing surfaces that **inferred** operator-supplied
 
 ### Future feature — flagged, NOT approved
 - **Hotel data enrichment** logged in §8 (Open Risks → Future features): must be scoped against standards §9 before any work (three distinct states: operator-stated / verified-with-source / Not provided; never silent-fill; operator can correct; disclose to users). The "Not provided" baseline from **this** fix is its prerequisite.
+
+---
+
+## 28. Operator Form — no silent defaults for skipped fields — 2026-06-13
+
+**Branch:** `fix/operator-form-no-silent-defaults` (off `dev`).
+**Tests:** 1,830/1,830 pass (27 files, +5 new) · `tsc --noEmit` clean · `npm run build` 0 errors.
+
+### Why
+The §27 fix made the *display* honest. This closes the upstream hole: the package wizard manufactured values for fields the operator skipped, so the DB stored a confident default (4-star / medium distance / small-group) as if the operator had confirmed it. The adapter was already honest (`?? null`) — the fabrication lived in `DEFAULT_DATA` and the Zod `.default()` calls. A skipped field must now persist as genuinely unset → render "Not provided" everywhere (matching §27 / PR #64).
+
+### Scope — three fields only
+**Hotel stars · distance band · group type.** Inclusions are OUT of scope (see deferred follow-up below).
+
+### What changed
+- **Zod schema extracted** to `lib/operator/package-schema.ts` (imported by `app/api/operator/packages/route.ts`; makes the defaults unit-testable). Distance `.default('medium')` → **`.default('unknown')`** — `'unknown'` is the existing "Not provided" sentinel (`comparison.ts:108-109`, `friendlyDistance` → null). Stars and `groupType` keep **no default** (`.optional()`).
+- **`PackageWizard.tsx` `DEFAULT_DATA`**: removed the `distanceBandMakkah/Madinah: 'medium'` and `groupType: 'small-group'` seeds (stars were never seeded).
+- **`WizardStep3Hotels.tsx`** — stars: removed the `?? 4` UI paint; select now starts on a disabled **"Select hotel class"** placeholder, with an explicit **"Not sure / not rated"** option → `undefined`. Removed the misleading required `*` on stars. Distance: removed the `'unknown' → 'medium'` display coercion; added a **"Not specified"** option (= `'unknown'`); parent default `?? 'unknown'`.
+- **`WizardStep6Policies.tsx`** — group type: removed the `?? 'small-group'` default; added a **"Not specified"** radio (value `undefined`) as the starting state.
+- **`WizardStep8Review.tsx`** — distance rows show "Not set" when `'unknown'` (instead of the literal "unknown"). Stars/group already showed "Not set" for unset.
+
+### Verified end to end (package created skipping all three)
+- Schema persists: stars `undefined`, distance `'unknown'`, groupType `undefined`.
+- Adapter writes: stars `null`, distance `'unknown'`, groupType `null` (`adapter.ts:385,386,400`).
+- Pilgrim sees (comparison grid): **"Not provided"** for hotel rating, distance, and group type.
+- Chosen values pass through unchanged (5★ / near / Private → rendered).
+- Theme/layout: only `<option>`/radio additions to existing token-styled selects — no new colours, no width/layout change, so both themes + 390px are unaffected (existing operator e2e still green). Pre-existing hardcoded `rgba(255,255,255,…)` wizard inputs left untouched per scope; new additions are token-only.
+
+### Existing data (report only — NO migration this task)
+Counts of records currently holding the old default-equivalent value (seed-authored; live DB not queried):
+- `lib/api/mock-db.ts` (17 pkgs): stars=4 → 8 Makkah / 9 Madinah; distance='medium' → 7 Makkah / 3 Madinah; groupType='small-group' → 6/17.
+- `prisma/seed.ts` (14 pkgs): stars=4 → 5 Makkah / 5 Madinah; distance uses an out-of-type vocabulary (`'0-500m'`/`'500m-1km'`/`'1km+'`), 0 `'medium'`; no `groupType` set.
+- `supabase/seed.sql`: 0 package records.
+Existing-data cleanup (whether to null-out these seed defaults) is a **separate later task** — not done here.
+
+### Deferred / flagged as separate tasks
+- **Inclusions three-state model (follow-up):** inclusions still default all-false. That direction is safe (it under-claims — never marks something included that the operator didn't confirm), so it was left as-is. A proper three-state model (included / not included / not specified) is a separate follow-up.
+- **Distance vocabulary reconciliation (separate task):** three vocabularies coexist — the type enum (`near|medium|far|unknown`), the wizard labels, and the DB seed strings (`'0-500m'` etc. in `prisma/seed.ts`, outside the enum). This fix deliberately did **not** touch the vocabulary; reconciling them is its own task.
+- **Edit-mode clearing limitation:** PATCH uses `packageSchema.partial()` and `JSON.stringify` drops `undefined`, so clearing a previously-set optional field (e.g. changing 5★ back to "Not sure") via edit does not persist a null. The type models these as `?:` (optional), not nullable, so explicit-null clearing is out of scope here. Create-flow (the task's focus) is unaffected.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -7,13 +7,13 @@
 
 **Stack:** Next.js 15.5 (App Router, Server Components) · React 19 · TypeScript strict · Supabase (auth/Postgres/RLS/storage, `eu-west-2`) · Prisma · Tailwind · Zustand · Vitest + Playwright.
 
-**State (2026-06-13):** Production on `main` (PR #54). Tests 1,825/1,825 ✅. Build clean ✅. Light theme + search redesign + pagination on `main`. Homepage redesign (audience routing + live compare preview) merged to `dev` (PR #63). Data-integrity "Not provided" fix on `fix/data-integrity-not-provided` (PR → dev pending) — package cards, package JSON-LD, and quote prefill no longer infer missing hotel name/stars. Q1–Q6 quality passes complete. Full transactional email suite live (6 templates via Resend). 3 Vercel cron jobs active. `/how-we-rank` ranking transparency page live.
+**State (2026-06-13):** Production on `main` (PR #54). Tests 1,830/1,830 ✅. Build clean ✅. Light theme + search redesign + pagination on `main`. Homepage redesign merged to `dev` (PR #63). Data-integrity "Not provided" display fix merged to `dev` (PR #64) — cards, JSON-LD, quote prefill. Operator-form no-silent-defaults fix on `fix/operator-form-no-silent-defaults` (PR → dev pending) — wizard no longer saves default stars/distance/group type for skipped fields; they persist unset → "Not provided" (see AI_NOTES §28). Q1–Q6 quality passes complete. Full transactional email suite live. 3 Vercel cron jobs active.
 
 **Remaining setup items:** Operational only — curl-test 3 cron endpoints with CRON_SECRET, submit test enquiry to verify email delivery, onboard first operator. Email mailboxes live via Cloudflare Email Routing (→ Gmail). Upgrade to Google Workspace when onboarding real operators.
 
 **How to verify any change (mandatory before push):**
 ```bash
-npm run test     # 1,825/1,825 must pass
+npm run test     # 1,830/1,830 must pass
 npm run build    # 0 errors
 npx tsc --noEmit # pass
 # if UI/routes changed: Playwright smoke on / , /umrah , /search/packages at 320px + 1280px

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 > **Single rolling tracker.** Any AI/dev: read this for current state. Update it after work is **done + tested + verified** (see `CLAUDE.md` rule).
 > Detailed handover lives in `AI_NOTES.md`. Cold-start brief: `HANDOFF.md`. Business: `BUSINESS.md`.
 
-**Last verified:** 2026-06-13 (data-integrity "Not provided" fix) · **Branch:** `fix/data-integrity-not-provided` (PR → dev pending) · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
+**Last verified:** 2026-06-13 (operator-form no-silent-defaults) · **Branch:** `fix/operator-form-no-silent-defaults` (PR → dev pending) · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
 
 ---
 
@@ -11,7 +11,7 @@
 
 | Check | State |
 | --- | --- |
-| `npm run test` | ✅ 1,825/1,825 pass (26 files) |
+| `npm run test` | ✅ 1,830/1,830 pass (27 files) |
 | `npm run build` | ✅ 0 errors |
 | `npx tsc --noEmit` | ✅ pass |
 | E2E `e2e/operator.spec.ts` | ✅ 30/30 pass (chromium + firefox + webkit) |
@@ -130,7 +130,11 @@
 | Search header redesign (world-class) | ✅ Done 2026-06-13 (merged to dev + main) | — |
 | Search results pagination (5/page) | ✅ Done 2026-06-13 (merged to dev + main) | — |
 | Homepage redesign — audience routing + live compare preview | ✅ Done 2026-06-13 (PR #63 → dev) | — |
-| Data integrity — "Not provided" for missing hotel name/stars (cards, JSON-LD, quote prefill) | ✅ Done 2026-06-13 (PR → dev pending, see AI_NOTES §27) | — |
+| Data integrity — "Not provided" for missing hotel name/stars (cards, JSON-LD, quote prefill) | ✅ Done 2026-06-13 (PR #64 → dev, see AI_NOTES §27) | — |
+| Operator form — no silent defaults for skipped stars/distance/group type | ✅ Done 2026-06-13 (PR → dev pending, see AI_NOTES §28) | — |
+| Inclusions three-state model (included / not / not specified) | ⏳ Not started | Follow-up to §28 |
+| Distance vocabulary reconciliation (enum vs wizard vs DB '0-500m') | ⏳ Not started | Separate task (flagged §28) |
+| Existing-data cleanup — null out seed default stars/distance/group | ⏳ Not started | Separate task (flagged §28) |
 | Plausible analytics wiring | ⏳ Not started | — |
 | `app_metadata.role` backfill (pre-2026-06-09 users) | ⏳ Not started | Needs Supabase SQL |
 | Registered office address in footer | ⏳ Not started | Awaiting virtual office |

--- a/app/api/operator/packages/route.ts
+++ b/app/api/operator/packages/route.ts
@@ -3,73 +3,7 @@ import { getSessionUser } from '@/lib/auth/session';
 import { Repository } from '@/lib/api/repository';
 import { mapErrorToResponse } from '@/lib/errors';
 import type { Package } from '@/lib/types';
-import { AIRPORT_CODES } from '@/lib/airports';
-import { z } from 'zod';
-
-// ─── Zod schema ──────────────────────────────────────────────────────────────
-
-const inclusionsSchema = z.object({
-  visa: z.boolean(),
-  flights: z.boolean(),
-  transfers: z.boolean(),
-  meals: z.boolean(),
-});
-
-const roomOccupancySchema = z.object({
-  single: z.boolean(),
-  double: z.boolean(),
-  triple: z.boolean(),
-  quad: z.boolean(),
-});
-
-const airportCodeSchema = z.enum(AIRPORT_CODES);
-
-const packageSchema = z.object({
-  // Step 1 — required
-  title: z.string().min(5, 'Title must be at least 5 characters').max(120, 'Title must be 120 characters or fewer'),
-  pilgrimageType: z.enum(['umrah', 'hajj']),
-  // Step 1 — optional
-  seasonLabel: z.string().max(80).optional(),
-  dateWindow: z.object({
-    start: z.string().default(''),
-    end: z.string().default(''),
-  }).optional(),
-  // Step 2 — required
-  pricePerPerson: z.number().positive('Price must be greater than 0'),
-  priceType: z.enum(['exact', 'from', 'fixed']),
-  currency: z.literal('GBP').default('GBP'),
-  // Step 2 — optional
-  depositAmount: z.number().nonnegative().optional(),
-  paymentPlanAvailable: z.boolean().optional(),
-  // Step 3
-  nightsMakkah: z.number().int().min(1, 'Makkah nights must be at least 1'),
-  nightsMadinah: z.number().int().min(1, 'Madinah nights must be at least 1'),
-  totalNights: z.number().int().min(2),
-  hotelMakkahName: z.string().optional(),
-  hotelMakkahStars: z.union([z.literal(3), z.literal(4), z.literal(5)]).optional(),
-  distanceBandMakkah: z.enum(['near', 'medium', 'far', 'unknown']).default('medium'),
-  distanceToHaramMakkahMetres: z.number().int().nonnegative().optional(),
-  hotelMadinahName: z.string().optional(),
-  hotelMadinahStars: z.union([z.literal(3), z.literal(4), z.literal(5)]).optional(),
-  distanceBandMadinah: z.enum(['near', 'medium', 'far', 'unknown']).default('medium'),
-  distanceToHaramMadinahMetres: z.number().int().nonnegative().optional(),
-  // Step 4
-  airline: z.string().optional(),
-  departureAirport: airportCodeSchema.optional(),
-  flightType: z.enum(['direct', 'one-stop', 'multi-stop']).optional(),
-  // Step 5
-  inclusions: inclusionsSchema.default({ visa: false, flights: false, transfers: false, meals: false }),
-  roomOccupancyOptions: roomOccupancySchema.default({ single: false, double: true, triple: true, quad: true }),
-  // Step 6
-  cancellationPolicy: z.string().max(1000).optional(),
-  groupType: z.enum(['private', 'small-group', 'large-group']).optional(),
-  // Step 7
-  highlights: z.array(z.string().max(200)).max(5).optional(),
-  notes: z.string().max(2000).optional(),
-  images: z.array(z.string().url()).max(8).optional(),
-  // Step 8 — publish status
-  status: z.enum(['draft', 'published']).default('draft'),
-});
+import { packageSchema, updatePackageSchema } from '@/lib/operator/package-schema';
 
 // ─── POST — create package ────────────────────────────────────────────────────
 
@@ -151,9 +85,7 @@ export async function DELETE(_request: NextRequest) {
 
 // ─── PATCH — update package ───────────────────────────────────────────────────
 
-const updateSchema = packageSchema.partial().extend({
-  id: z.string().min(1, 'Package ID required'),
-});
+const updateSchema = updatePackageSchema;
 
 export async function PATCH(request: NextRequest) {
   try {

--- a/components/operator/wizard/PackageWizard.tsx
+++ b/components/operator/wizard/PackageWizard.tsx
@@ -47,15 +47,16 @@ const VALIDATORS: ((data: Partial<Package>) => string | null)[] = [
 
 // ─── Defaults ─────────────────────────────────────────────────────────────────
 
+// Only fields the operator cannot meaningfully "skip" are seeded. Hotel stars,
+// distance band, and group type are deliberately NOT seeded — a skipped value
+// must persist as genuinely unset (→ "Not provided"), never a painted default.
+// (Inclusions keep all-false: the safe, non-over-claiming direction. See AI_NOTES §28.)
 const DEFAULT_DATA: Partial<Package> = {
   pilgrimageType: 'umrah',
   priceType: 'from',
   currency: 'GBP',
   inclusions: { visa: false, flights: false, transfers: false, meals: false },
   roomOccupancyOptions: { single: false, double: true, triple: true, quad: true },
-  distanceBandMakkah: 'medium',
-  distanceBandMadinah: 'medium',
-  groupType: 'small-group',
 };
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/components/operator/wizard/WizardStep3Hotels.tsx
+++ b/components/operator/wizard/WizardStep3Hotels.tsx
@@ -32,13 +32,13 @@ function HotelSection({
   city: string;
   prefix: string;
   nameValue: string;
-  starsValue: 3 | 4 | 5;
+  starsValue: 3 | 4 | 5 | undefined;
   distanceValue: 'near' | 'medium' | 'far' | 'unknown';
   nightsValue: number;
   distMetresValue: number | undefined;
   onNameChange: (v: string) => void;
-  onStarsChange: (v: 3 | 4 | 5) => void;
-  onDistanceChange: (v: 'near' | 'medium' | 'far') => void;
+  onStarsChange: (v: 3 | 4 | 5 | undefined) => void;
+  onDistanceChange: (v: 'near' | 'medium' | 'far' | 'unknown') => void;
   onNightsChange: (v: number) => void;
   onDistMetresChange: (v: number | undefined) => void;
 }) {
@@ -62,15 +62,22 @@ function HotelSection({
 
         <div>
           <label htmlFor={`${prefix}-stars`} className="mb-1.5 block text-sm font-medium text-[var(--textMuted)]">
-            Star rating <span aria-hidden="true" className="text-[var(--color-error)]">*</span>
+            Star rating
           </label>
           <select
             id={`${prefix}-stars`}
             data-testid={`${prefix}-stars`}
-            value={starsValue}
-            onChange={(e) => onStarsChange(parseInt(e.target.value) as 3 | 4 | 5)}
+            // Starts empty (placeholder) — no painted default. Unset persists as
+            // "Not provided"; "Not sure / not rated" is the explicit unset choice.
+            value={starsValue ?? ''}
+            onChange={(e) => {
+              const v = e.target.value;
+              onStarsChange(v === '' || v === 'not-rated' ? undefined : (parseInt(v) as 3 | 4 | 5));
+            }}
             className="w-full rounded border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.05)] px-3 py-2 text-sm text-[var(--text)] focus:border-[var(--yellow)] focus:outline-none"
           >
+            <option value="" disabled>Select hotel class</option>
+            <option value="not-rated">Not sure / not rated</option>
             {STAR_OPTIONS.map((s) => (
               <option key={s} value={s}>{s} stars</option>
             ))}
@@ -97,10 +104,13 @@ function HotelSection({
           <select
             id={`${prefix}-distance`}
             data-testid={`${prefix}-distance`}
-            value={distanceValue === 'unknown' ? 'medium' : distanceValue}
-            onChange={(e) => onDistanceChange(e.target.value as 'near' | 'medium' | 'far')}
+            // 'unknown' is the honest unset value (renders "Not provided"); shown
+            // as "Not specified" rather than silently coerced to 'medium'.
+            value={distanceValue}
+            onChange={(e) => onDistanceChange(e.target.value as 'near' | 'medium' | 'far' | 'unknown')}
             className="w-full rounded border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.05)] px-3 py-2 text-sm text-[var(--text)] focus:border-[var(--yellow)] focus:outline-none"
           >
+            <option value="unknown">Not specified</option>
             {DISTANCE_OPTIONS.map((d) => (
               <option key={d.value} value={d.value}>{d.label}</option>
             ))}
@@ -148,8 +158,8 @@ export function WizardStep3Hotels({ data, onChange, error }: Props) {
         city="Makkah"
         prefix="makkah"
         nameValue={data.hotelMakkahName ?? ''}
-        starsValue={data.hotelMakkahStars ?? 4}
-        distanceValue={data.distanceBandMakkah ?? 'medium'}
+        starsValue={data.hotelMakkahStars}
+        distanceValue={data.distanceBandMakkah ?? 'unknown'}
         nightsValue={data.nightsMakkah ?? 0}
         distMetresValue={data.distanceToHaramMakkahMetres}
         onNameChange={(v) => onChange({ hotelMakkahName: v })}
@@ -163,8 +173,8 @@ export function WizardStep3Hotels({ data, onChange, error }: Props) {
         city="Madinah"
         prefix="madinah"
         nameValue={data.hotelMadinahName ?? ''}
-        starsValue={data.hotelMadinahStars ?? 4}
-        distanceValue={data.distanceBandMadinah ?? 'medium'}
+        starsValue={data.hotelMadinahStars}
+        distanceValue={data.distanceBandMadinah ?? 'unknown'}
         nightsValue={data.nightsMadinah ?? 0}
         distMetresValue={data.distanceToHaramMadinahMetres}
         onNameChange={(v) => onChange({ hotelMadinahName: v })}

--- a/components/operator/wizard/WizardStep6Policies.tsx
+++ b/components/operator/wizard/WizardStep6Policies.tsx
@@ -8,15 +8,19 @@ interface Props {
   error: string | null;
 }
 
-const GROUP_TYPES: { value: Package['groupType']; label: string; description: string }[] = [
-  { value: 'private', label: 'Private', description: 'Dedicated group for your party only' },
-  { value: 'small-group', label: 'Small group', description: 'Shared with up to ~15 pilgrims' },
-  { value: 'large-group', label: 'Large group', description: 'Shared with 16+ pilgrims' },
+// 'Not specified' (value: undefined) is offered explicitly and is the starting
+// state — no painted default. A skipped group type persists as unset and reads
+// as "Not provided" downstream. The `key` gives each radio a stable DOM value.
+const GROUP_OPTIONS: { value: Package['groupType']; key: string; label: string; description: string }[] = [
+  { value: undefined, key: 'unspecified', label: 'Not specified', description: 'Leave blank — shown to pilgrims as "Not provided".' },
+  { value: 'private', key: 'private', label: 'Private', description: 'Dedicated group for your party only' },
+  { value: 'small-group', key: 'small-group', label: 'Small group', description: 'Shared with up to ~15 pilgrims' },
+  { value: 'large-group', key: 'large-group', label: 'Large group', description: 'Shared with 16+ pilgrims' },
 ];
 
 export function WizardStep6Policies({ data, onChange, error }: Props) {
   const policy = data.cancellationPolicy ?? '';
-  const groupType = data.groupType ?? 'small-group';
+  const groupType = data.groupType;
   const charCount = policy.length;
 
   return (
@@ -57,9 +61,9 @@ export function WizardStep6Policies({ data, onChange, error }: Props) {
       <div>
         <h3 className="mb-3 text-sm font-semibold text-[var(--text)] uppercase tracking-wide">Group type</h3>
         <div className="space-y-2">
-          {GROUP_TYPES.map(({ value, label, description }) => (
+          {GROUP_OPTIONS.map(({ value, key, label, description }) => (
             <label
-              key={value}
+              key={key}
               className={`flex cursor-pointer items-center gap-3 rounded border px-4 py-3 transition-colors ${
                 groupType === value
                   ? 'border-[var(--yellow)]/50 bg-[var(--yellow)]/10'
@@ -69,8 +73,8 @@ export function WizardStep6Policies({ data, onChange, error }: Props) {
               <input
                 type="radio"
                 name="group-type"
-                data-testid={`wizard-group-${value}`}
-                value={value}
+                data-testid={`wizard-group-${key}`}
+                value={key}
                 checked={groupType === value}
                 onChange={() => onChange({ groupType: value })}
                 className="h-4 w-4 accent-[var(--yellow)]"

--- a/components/operator/wizard/WizardStep8Review.tsx
+++ b/components/operator/wizard/WizardStep8Review.tsx
@@ -91,11 +91,11 @@ export function WizardStep8Review({ data, onSaveDraft, onPublish, isSaving, erro
         <ReviewRow label="Makkah hotel" value={data.hotelMakkahName} />
         <ReviewRow label="Makkah stars" value={data.hotelMakkahStars ? `${data.hotelMakkahStars}★` : undefined} />
         <ReviewRow label="Makkah nights" value={data.nightsMakkah} />
-        <ReviewRow label="Makkah distance" value={data.distanceBandMakkah} />
+        <ReviewRow label="Makkah distance" value={data.distanceBandMakkah && data.distanceBandMakkah !== 'unknown' ? data.distanceBandMakkah : undefined} />
         <ReviewRow label="Madinah hotel" value={data.hotelMadinahName} />
         <ReviewRow label="Madinah stars" value={data.hotelMadinahStars ? `${data.hotelMadinahStars}★` : undefined} />
         <ReviewRow label="Madinah nights" value={data.nightsMadinah} />
-        <ReviewRow label="Madinah distance" value={data.distanceBandMadinah} />
+        <ReviewRow label="Madinah distance" value={data.distanceBandMadinah && data.distanceBandMadinah !== 'unknown' ? data.distanceBandMadinah : undefined} />
         <ReviewRow label="Total nights" value={data.totalNights} />
       </ReviewSection>
 

--- a/lib/operator/package-schema.ts
+++ b/lib/operator/package-schema.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+import { AIRPORT_CODES } from '@/lib/airports';
+
+// ─── Operator package create/update schema ────────────────────────────────────
+// Shared by the API route and unit tests.
+//
+// Data-integrity rule (see AI_NOTES §27/§28): the form must never manufacture a
+// value the operator did not choose. So the only defaults here are honest ones:
+//   - distance bands default to 'unknown' (the existing "Not provided" sentinel),
+//     NOT 'medium' — a skipped distance reads as "Not provided" downstream.
+//   - hotel stars and group type have NO default — skipped = absent (→ null in
+//     the adapter → "Not provided").
+//   - inclusions keep the all-false default (out of scope here; a three-state
+//     inclusions model is a separate follow-up — see AI_NOTES §28).
+
+const inclusionsSchema = z.object({
+  visa: z.boolean(),
+  flights: z.boolean(),
+  transfers: z.boolean(),
+  meals: z.boolean(),
+});
+
+const roomOccupancySchema = z.object({
+  single: z.boolean(),
+  double: z.boolean(),
+  triple: z.boolean(),
+  quad: z.boolean(),
+});
+
+const airportCodeSchema = z.enum(AIRPORT_CODES);
+
+export const packageSchema = z.object({
+  // Step 1 — required
+  title: z.string().min(5, 'Title must be at least 5 characters').max(120, 'Title must be 120 characters or fewer'),
+  pilgrimageType: z.enum(['umrah', 'hajj']),
+  // Step 1 — optional
+  seasonLabel: z.string().max(80).optional(),
+  dateWindow: z.object({
+    start: z.string().default(''),
+    end: z.string().default(''),
+  }).optional(),
+  // Step 2 — required
+  pricePerPerson: z.number().positive('Price must be greater than 0'),
+  priceType: z.enum(['exact', 'from', 'fixed']),
+  currency: z.literal('GBP').default('GBP'),
+  // Step 2 — optional
+  depositAmount: z.number().nonnegative().optional(),
+  paymentPlanAvailable: z.boolean().optional(),
+  // Step 3
+  nightsMakkah: z.number().int().min(1, 'Makkah nights must be at least 1'),
+  nightsMadinah: z.number().int().min(1, 'Madinah nights must be at least 1'),
+  totalNights: z.number().int().min(2),
+  hotelMakkahName: z.string().optional(),
+  // No default — a skipped star rating stays absent (→ "Not provided").
+  hotelMakkahStars: z.union([z.literal(3), z.literal(4), z.literal(5)]).optional(),
+  // 'unknown' is the honest unset sentinel (renders "Not provided"); never 'medium'.
+  distanceBandMakkah: z.enum(['near', 'medium', 'far', 'unknown']).default('unknown'),
+  distanceToHaramMakkahMetres: z.number().int().nonnegative().optional(),
+  hotelMadinahName: z.string().optional(),
+  hotelMadinahStars: z.union([z.literal(3), z.literal(4), z.literal(5)]).optional(),
+  distanceBandMadinah: z.enum(['near', 'medium', 'far', 'unknown']).default('unknown'),
+  distanceToHaramMadinahMetres: z.number().int().nonnegative().optional(),
+  // Step 4
+  airline: z.string().optional(),
+  departureAirport: airportCodeSchema.optional(),
+  flightType: z.enum(['direct', 'one-stop', 'multi-stop']).optional(),
+  // Step 5
+  inclusions: inclusionsSchema.default({ visa: false, flights: false, transfers: false, meals: false }),
+  roomOccupancyOptions: roomOccupancySchema.default({ single: false, double: true, triple: true, quad: true }),
+  // Step 6 — no default: a skipped group type stays absent (→ "Not provided").
+  cancellationPolicy: z.string().max(1000).optional(),
+  groupType: z.enum(['private', 'small-group', 'large-group']).optional(),
+  // Step 7
+  highlights: z.array(z.string().max(200)).max(5).optional(),
+  notes: z.string().max(2000).optional(),
+  images: z.array(z.string().url()).max(8).optional(),
+  // Step 8 — publish status
+  status: z.enum(['draft', 'published']).default('draft'),
+});
+
+export const updatePackageSchema = packageSchema.partial().extend({
+  id: z.string().min(1, 'Package ID required'),
+});
+
+export type PackageSchemaInput = z.input<typeof packageSchema>;
+export type PackageSchemaOutput = z.output<typeof packageSchema>;

--- a/tests/operator-form-defaults.test.ts
+++ b/tests/operator-form-defaults.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { packageSchema } from '@/lib/operator/package-schema';
+import { mapPackageToComparison } from '@/lib/comparison';
+import type { Package } from '@/lib/types';
+
+// Minimal valid create payload that SKIPS hotel stars, distance band, and group
+// type — exactly what the wizard sends when an operator leaves those untouched.
+const skippedPayload = {
+  title: 'Umrah package deal',
+  pilgrimageType: 'umrah' as const,
+  pricePerPerson: 1200,
+  priceType: 'from' as const,
+  nightsMakkah: 5,
+  nightsMadinah: 5,
+  totalNights: 10,
+};
+
+describe('package-schema — skipped fields stay unset (no silent defaults)', () => {
+  it('defaults distance band to the "unknown" sentinel, never "medium"', () => {
+    const parsed = packageSchema.parse(skippedPayload);
+    expect(parsed.distanceBandMakkah).toBe('unknown');
+    expect(parsed.distanceBandMadinah).toBe('unknown');
+  });
+
+  it('leaves hotel stars and group type absent when skipped', () => {
+    const parsed = packageSchema.parse(skippedPayload);
+    expect(parsed.hotelMakkahStars).toBeUndefined();
+    expect(parsed.hotelMadinahStars).toBeUndefined();
+    expect(parsed.groupType).toBeUndefined();
+  });
+
+  it('preserves operator-chosen values unchanged', () => {
+    const parsed = packageSchema.parse({
+      ...skippedPayload,
+      hotelMakkahStars: 5,
+      hotelMadinahStars: 4,
+      distanceBandMakkah: 'near',
+      distanceBandMadinah: 'far',
+      groupType: 'private',
+    });
+    expect(parsed.hotelMakkahStars).toBe(5);
+    expect(parsed.hotelMadinahStars).toBe(4);
+    expect(parsed.distanceBandMakkah).toBe('near');
+    expect(parsed.distanceBandMadinah).toBe('far');
+    expect(parsed.groupType).toBe('private');
+  });
+});
+
+// Build a full Package from a parsed schema result so we exercise the real
+// downstream renderer (the comparison grid) end to end.
+const toPackage = (parsed: ReturnType<typeof packageSchema.parse>): Package =>
+  ({
+    id: 'pkg-1',
+    operatorId: 'op1',
+    slug: 'umrah-package-deal',
+    seasonLabel: 'Flexible',
+    ...parsed,
+  }) as unknown as Package;
+
+describe('downstream — unset wizard fields render "Not provided"', () => {
+  it('shows "Not provided" for skipped stars, distance, and group type', () => {
+    const row = mapPackageToComparison(toPackage(packageSchema.parse(skippedPayload)));
+    expect(row.hotelRating).toBe('Not provided');
+    expect(row.distance).toBe('Not provided');
+    expect(row.groupType).toBe('Not provided');
+  });
+
+  it('shows the chosen values when the operator selected them', () => {
+    const row = mapPackageToComparison(
+      toPackage(
+        packageSchema.parse({
+          ...skippedPayload,
+          hotelMakkahStars: 5,
+          hotelMadinahStars: 4,
+          distanceBandMakkah: 'near',
+          distanceBandMadinah: 'far',
+          groupType: 'private',
+        })
+      )
+    );
+    expect(row.hotelRating).toBe('Makkah 5 / Madinah 4');
+    expect(row.distance).toBe('Makkah near / Madinah far');
+    expect(row.groupType).toBe('Private');
+  });
+});


### PR DESCRIPTION
## Why

The §27 / PR #64 fix made the *display* honest. This closes the **upstream** hole: the package wizard manufactured values for fields the operator skipped, so the DB stored a confident default (4-star / medium distance / small-group) as if the operator had confirmed it. The adapter was already honest (`?? null`) — the fabrication lived in `DEFAULT_DATA` and the Zod `.default()` calls.

A skipped field now persists as **genuinely unset** and renders **"Not provided"** everywhere downstream.

## Scope — three fields only
Hotel stars · distance band · group type. **Inclusions are out of scope** (their all-false default is the safe, non-over-claiming direction; a three-state model is a deferred follow-up).

## Changes
- **Zod schema extracted** to `lib/operator/package-schema.ts` (imported by the route; makes defaults unit-testable). Distance `.default('medium')` → **`.default('unknown')`** — `'unknown'` is the existing "Not provided" sentinel (`comparison.ts`, `friendlyDistance`). Stars + `groupType` keep no default.
- **`PackageWizard.tsx`** — removed the `distance: 'medium'` and `groupType: 'small-group'` seeds from `DEFAULT_DATA`.
- **`WizardStep3Hotels.tsx`** — stars: removed the `?? 4` paint; select starts on a **"Select hotel class"** placeholder + explicit **"Not sure / not rated"** → unset; dropped the misleading required `*`. Distance: **"Not specified"** option (= `'unknown'`), no `'medium'` coercion.
- **`WizardStep6Policies.tsx`** — group type: **"Not specified"** radio (unset) as the starting state; no default.
- **`WizardStep8Review.tsx`** — distance shows "Not set" for `'unknown'` instead of the literal.

## Verified end to end (package created skipping all three)
| Stage | stars | distance | groupType |
|---|---|---|---|
| Schema persists | `undefined` | `'unknown'` | `undefined` |
| Adapter writes (DB) | `null` | `'unknown'` | `null` |
| Pilgrim sees (compare grid) | **Not provided** | **Not provided** | **Not provided** |

Chosen values pass through unchanged (5★ / near / Private → rendered).

## Existing data (report only — no migration)
- `mock-db.ts` (17 pkgs): stars=4 → 8/9; distance='medium' → 7/3; groupType='small-group' → 6.
- `prisma/seed.ts` (14 pkgs): stars=4 → 5/5; distance uses out-of-type strings (`'0-500m'` …), 0 `'medium'`; no `groupType`.
- `supabase/seed.sql`: 0 records.

## Deferred / flagged (AI_NOTES §28)
- Inclusions three-state model (follow-up).
- Distance vocabulary reconciliation (enum vs wizard vs DB `'0-500m'`).
- Existing-data cleanup (null out seed defaults).
- Edit-mode clearing of an optional field (PATCH + `JSON.stringify` drops `undefined`) — create flow unaffected.

## Validation
- `npx tsc --noEmit` — pass
- `npm run test` — 1,830/1,830 (27 files, +5 new)
- `npm run build` — clean
- Only `<option>`/radio additions to existing token-styled selects — no new colours, no layout change → both themes + 390px unaffected; pre-existing hardcoded `rgba` inputs left untouched per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)