### PR TITLE
fix: logo icon in light theme, auth confirm session, quote submit 500

### DIFF
--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,9 +1,15 @@
 import { type EmailOtpType } from '@supabase/supabase-js';
 import { type NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createServerClient } from '@supabase/ssr';
 
 // Handles the magic link / OTP callback from Supabase confirmation emails.
 // Supabase sends users to: /auth/confirm?token_hash=...&type=signup&next=/
+//
+// IMPORTANT: We do NOT use `await cookies()` + createClient() here because
+// NextResponse.redirect() creates a fresh response that won't inherit cookies
+// written via the Next.js cookieStore. Instead we use createServerClient
+// directly with a custom setAll handler that writes cookies onto the redirect
+// response itself.
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const token_hash = searchParams.get('token_hash');
@@ -11,16 +17,45 @@ export async function GET(request: NextRequest) {
   const next = searchParams.get('next') ?? '/';
 
   if (token_hash && type) {
-    const supabase = await createClient();
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!url || !anonKey) {
+      return NextResponse.redirect(new URL('/verify-email?error=config_error', origin));
+    }
+
+    // Collect cookies that verifyOtp wants to set, then apply them to the
+    // redirect response so the session is established on the client.
+    const pendingCookies: Array<{ name: string; value: string; options: Record<string, unknown> }> = [];
+
+    const supabase = createServerClient(url, anonKey, {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          pendingCookies.push(...cookiesToSet);
+        },
+      },
+    });
+
     const { error } = await supabase.auth.verifyOtp({ type, token_hash });
+
     if (!error) {
       const { data: { user } } = await supabase.auth.getUser();
       const role = user?.app_metadata?.role;
-      // Operators go straight to onboarding to complete their company profile
       const destination = role === 'operator' && next === '/' ? '/operator/onboarding' : next;
       const redirectUrl = new URL(destination, origin);
       redirectUrl.searchParams.set('verified', '1');
-      return NextResponse.redirect(redirectUrl);
+
+      const response = NextResponse.redirect(redirectUrl);
+
+      // Apply session cookies from verifyOtp directly onto the redirect response
+      pendingCookies.forEach(({ name, value, options }) => {
+        response.cookies.set(name, value, options as Parameters<typeof response.cookies.set>[2]);
+      });
+
+      return response;
     }
   }
 

--- a/components/graphics/Logo.tsx
+++ b/components/graphics/Logo.tsx
@@ -16,7 +16,7 @@ export const Logo: React.FC<LogoProps> = ({
 }) => {
   return (
     <Image
-      src={isLight ? '/text-logo-light.svg' : '/logo.svg'}
+      src="/logo.svg"
       alt="PilgrimCompare Logo"
       width={size}
       height={size}

--- a/lib/auth/api.ts
+++ b/lib/auth/api.ts
@@ -53,6 +53,10 @@ export async function apiSignUp(input: SignUpInput) {
       // customer, which is a confusing security-relevant state. Surface as 500.
       throw new AppError({ code: 'INTERNAL_ERROR', status: 500 });
     }
+
+    // Sync to Prisma users table so quote_requests FK constraint is satisfied.
+    const name = (data.user?.user_metadata?.name as string) || input.name || null;
+    await syncUserToPrisma(userId, input.email, input.role, name);
   }
 
   return data;
@@ -76,7 +80,47 @@ export async function apiSignIn(input: SignInInput) {
     }
     throw new AppError({ code: 'AUTH_INVALID_CREDENTIALS', status: 401 });
   }
+
+  // Sync to Prisma users table on every sign-in. This covers users who signed
+  // up before the FK sync was added — their Prisma row is created on first login.
+  const signedInUser = data.user;
+  if (signedInUser?.id) {
+    const role = (signedInUser.app_metadata?.role as string) || 'customer';
+    const name = (signedInUser.user_metadata?.name as string) || null;
+    await syncUserToPrisma(signedInUser.id, signedInUser.email!, role, name);
+  }
+
   return data;
+}
+
+/**
+ * Upsert a row in the Prisma `users` table to match the Supabase auth user.
+ * Required because quote_requests.customer_id has a FK to users.id.
+ * Only runs when FEATURE_USE_REAL_DB=true (skipped in E2E / test mode).
+ * Errors are logged but do not fail the caller — auth already succeeded.
+ */
+async function syncUserToPrisma(
+  userId: string,
+  email: string,
+  role: string,
+  name?: string | null,
+): Promise<void> {
+  if (process.env.FEATURE_USE_REAL_DB !== 'true') return;
+  try {
+    const { prisma } = await import('@/lib/api/db/prisma');
+    await prisma.user.upsert({
+      where: { id: userId },
+      create: {
+        id: userId,
+        email,
+        role: (role as 'customer' | 'operator' | 'admin'),
+        name: name ?? null,
+      },
+      update: { email, name: name ?? null },
+    });
+  } catch (err) {
+    console.error('[auth] Failed to sync user to Prisma users table:', err);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Three production bugs found by manual testing on pilgrimcompare.co.uk.

- **Logo missing in light theme** — `Logo` component loaded `text-logo-light.svg` (a text-only SVG) while `WordmarkLogo` also rendered the brand name as text. Result: two text instances, no kaaba icon. Fixed: `Logo` always uses `logo.svg`.

- **Email confirm link doesn't sign user in (Bug A)** — `verifyOtp` writes session cookies via Supabase SSR, but `NextResponse.redirect()` creates a fresh response that doesn't inherit those cookies. User's email was verified but no session established → lands back on sign-in page. Fixed: `createServerClient` now uses a custom `setAll` handler that captures cookies and applies them explicitly to the redirect response.

- **Quote submit returns "Something went wrong" (Bug B)** — `apiSignUp` created a Supabase `auth.users` row but never inserted a corresponding row in the Prisma `users` table. `quote_requests.customer_id` has a FK to `users.id` → Prisma insert fails with FK violation → 500 `INTERNAL_ERROR`. Fixed: Prisma `users` row is upserted at both signup and signin. Signin coverage catches existing users who pre-date this fix.

## Test plan

- [ ] Sign up with new email → receive confirmation email → click link → lands signed in (not back on sign-in page)
- [ ] While signed in, go to /quote, complete all steps, submit → redirected to /requests/[id] (no "Something went wrong")
- [ ] Toggle light theme → kaaba icon visible in header alongside PilgrimCompare wordmark (not just text twice)
- [ ] All 1,830 Vitest tests pass, build clean, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)