### PR TITLE
fix: duplicate email signup error with sign-in link

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1206,3 +1206,29 @@ Existing-data cleanup (whether to null-out these seed defaults) is a **separate 
 - **Inclusions three-state model (follow-up):** inclusions still default all-false. That direction is safe (it under-claims — never marks something included that the operator didn't confirm), so it was left as-is. A proper three-state model (included / not included / not specified) is a separate follow-up.
 - **Distance vocabulary reconciliation (separate task):** three vocabularies coexist — the type enum (`near|medium|far|unknown`), the wizard labels, and the DB seed strings (`'0-500m'` etc. in `prisma/seed.ts`, outside the enum). This fix deliberately did **not** touch the vocabulary; reconciling them is its own task.
 - **Edit-mode clearing limitation:** PATCH uses `packageSchema.partial()` and `JSON.stringify` drops `undefined`, so clearing a previously-set optional field (e.g. changing 5★ back to "Not sure") via edit does not persist a null. The type models these as `?:` (optional), not nullable, so explicit-null clearing is out of scope here. Create-flow (the task's focus) is unaffected.
+
+---
+
+## 29. Duplicate email signup error + header logo link + knowledge base — 2026-06-14
+
+**Branch:** `dev`
+**Tests:** 1,830/1,830 pass (27 files, 0 new tests) · `tsc --noEmit` clean · `npm run build` clean.
+
+### Duplicate email signup error (Task 1)
+- `lib/errors.ts` — added `AUTH_EMAIL_ALREADY_EXISTS` error code + user-facing message.
+- `lib/auth/api.ts` — `apiSignUp` now detects Supabase "User already registered" / "email_address_already_registered" error messages and throws `AppError({ code: 'AUTH_EMAIL_ALREADY_EXISTS', status: 409 })` instead of a plain `Error` (which was masked to the generic INTERNAL_ERROR).
+- `components/auth/SignUpForm.tsx` — added `isDuplicateEmail` state; on `AUTH_EMAIL_ALREADY_EXISTS` response code, renders "An account with this email already exists. [Sign in instead]." with a link to `/login?type=operator` or `/login?type=customer` depending on role tab. All other error paths unchanged.
+
+### Header logo link (Task 2)
+Already implemented in prior work — `Header.tsx` line 231 wraps both Logo + WordmarkLogo in `<Link href="/" aria-label="PilgrimCompare - Go to homepage">`. No change needed.
+
+### Quote email investigation (Task 3) — findings only, no code change
+**RESEND_API_KEY:** present in `.env.local` ✓
+**FROM domain:** `send.pilgrimcompare.co.uk` — verified on Resend per §§ in Done list above ✓
+**Email 2 (customer confirmation):** fires on every quote submission — no operator condition. If not arriving, check Resend dashboard logs for send errors. Most likely cause locally: dev `localhost` quotes bypass no env guard, but Resend may rate-limit or sandbox them.
+**Email 3 (operator alert):** fires **only** when `sourcePackageId` or `sourceOperatorId` is present on the quote and resolves to an operator with a non-null `contactEmail`. A quote submitted from `/quote` without targeting a specific package/operator → Email 3 is intentionally skipped.
+**Seed operator emails:** `hello@zamzamtravel.example.com` uses `.example.com` (reserved TLD) — Resend will reject sends to this address. `info@alhidayah.com` and `sales@makkahtours.com` are real-looking but likely unreachable domains.
+**Fix required:** For Email 3 to fire in production for real enquiries: ensure quote is submitted with a valid `sourcePackageId`/`sourceOperatorId`, and the resolved operator has a real `contactEmail`. For local testing: update seed operator emails to a Resend-verified test inbox.
+
+### Knowledge Base (Task 4)
+Created `PILGRIMCOMPARE_KNOWLEDGE_BASE.md` (root) with section 5 Technical State — test counts 1,830 unit / 19 E2E passing / 2 skipped / build clean / tsc clean.

--- a/PILGRIMCOMPARE_KNOWLEDGE_BASE.md
+++ b/PILGRIMCOMPARE_KNOWLEDGE_BASE.md
@@ -1,0 +1,14 @@
+# PilgrimCompare Knowledge Base
+
+## 5. Technical State
+
+### Test baseline
+
+| Layer | Status |
+|---|---|
+| Unit tests (Vitest) | 1,830 passing |
+| End-to-end (Playwright) | 19 passing, 2 skipped |
+| Build (`npm run build`) | Clean — 0 errors |
+| TypeScript (`npx tsc --noEmit`) | Clean — 0 errors |
+
+_Last updated: 2026-06-14_

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,11 +3,11 @@
 > **Single rolling tracker.** Any AI/dev: read this for current state. Update it after work is **done + tested + verified** (see `CLAUDE.md` rule).
 > Detailed handover lives in `AI_NOTES.md`. Cold-start brief: `HANDOFF.md`. Business: `BUSINESS.md`.
 
-**Last verified:** 2026-06-13 (operator-form no-silent-defaults) · **Branch:** `fix/operator-form-no-silent-defaults` (PR → dev pending) · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
+**Last verified:** 2026-06-14 (duplicate email error, knowledge base) · **Branch:** `dev` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
 
 ---
 
-## Health (verified 2026-06-13)
+## Health (verified 2026-06-14)
 
 | Check | State |
 | --- | --- |
@@ -132,6 +132,7 @@
 | Homepage redesign — audience routing + live compare preview | ✅ Done 2026-06-13 (PR #63 → dev) | — |
 | Data integrity — "Not provided" for missing hotel name/stars (cards, JSON-LD, quote prefill) | ✅ Done 2026-06-13 (PR #64 → dev, see AI_NOTES §27) | — |
 | Operator form — no silent defaults for skipped stars/distance/group type | ✅ Done 2026-06-13 (PR → dev pending, see AI_NOTES §28) | — |
+| Duplicate email signup shows specific error with sign-in link | ✅ Done 2026-06-14 (dev, see AI_NOTES §29) | — |
 | Inclusions three-state model (included / not / not specified) | ⏳ Not started | Follow-up to §28 |
 | Distance vocabulary reconciliation (enum vs wizard vs DB '0-500m') | ⏳ Not started | Separate task (flagged §28) |
 | Existing-data cleanup — null out seed default stars/distance/group | ⏳ Not started | Separate task (flagged §28) |

--- a/components/auth/SignUpForm.tsx
+++ b/components/auth/SignUpForm.tsx
@@ -123,6 +123,7 @@ export function SignUpForm() {
   const [marketingConsent, setMarketingConsent] = useState(false);
   const [termsAgreed, setTermsAgreed] = useState(false);
   const [error, setError] = useState('');
+  const [isDuplicateEmail, setIsDuplicateEmail] = useState(false);
   const [passwordError, setPasswordError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -132,6 +133,7 @@ export function SignUpForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
+    setIsDuplicateEmail(false);
     setPasswordError('');
     setLoading(true);
 
@@ -157,7 +159,11 @@ export function SignUpForm() {
       const data = await res.json();
 
       if (!res.ok) {
-        setError(data.error || 'Registration failed');
+        if (data.code === 'AUTH_EMAIL_ALREADY_EXISTS') {
+          setIsDuplicateEmail(true);
+        } else {
+          setError(data.error || 'Registration failed');
+        }
         setLoading(false);
         return;
       }
@@ -228,13 +234,26 @@ export function SignUpForm() {
         </div>
       )}
 
-      {error && (
+      {(isDuplicateEmail || error) && (
         <div
           className="rounded-md border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 px-4 py-3 text-sm text-[var(--color-error)]"
           role="alert"
           data-testid="signup-error"
         >
-          {error}
+          {isDuplicateEmail ? (
+            <>
+              An account with this email already exists.{' '}
+              <Link
+                href={role === 'operator' ? '/login?type=operator' : '/login?type=customer'}
+                className="underline font-medium"
+              >
+                Sign in instead
+              </Link>
+              .
+            </>
+          ) : (
+            error
+          )}
         </div>
       )}
 

--- a/lib/auth/api.ts
+++ b/lib/auth/api.ts
@@ -36,7 +36,16 @@ export async function apiSignUp(input: SignUpInput) {
         },
     },
   });
-  if (error) throw new Error(error.message);
+  if (error) {
+    const msg = error.message ?? '';
+    if (
+      msg.toLowerCase().includes('user already registered') ||
+      msg.toLowerCase().includes('email_address_already_registered')
+    ) {
+      throw new AppError({ code: 'AUTH_EMAIL_ALREADY_EXISTS', status: 409 });
+    }
+    throw new Error(msg);
+  }
 
   // SECURITY: write the authorization role to app_metadata, which only the service
   // role can set. This is the single trusted source read by getSessionUser(),

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -8,6 +8,7 @@ export type ErrorCode =
   | 'AUTH_INVALID_CREDENTIALS'
   | 'AUTH_EMAIL_NOT_CONFIRMED'
   | 'AUTH_EMAIL_NOT_VERIFIED'
+  | 'AUTH_EMAIL_ALREADY_EXISTS'
   | 'UNAUTHORIZED'
   | 'FORBIDDEN'
   | 'VALIDATION_ERROR'
@@ -26,6 +27,7 @@ const USER_FACING_MESSAGES: Record<ErrorCode, string> = {
   AUTH_INVALID_CREDENTIALS: 'Invalid email or password.',
   AUTH_EMAIL_NOT_CONFIRMED: 'Please verify your email address before signing in. Check your inbox for a verification link.',
   AUTH_EMAIL_NOT_VERIFIED: 'Please verify your email address before performing this action.',
+  AUTH_EMAIL_ALREADY_EXISTS: 'An account with this email already exists. Please sign in instead.',
   UNAUTHORIZED: 'You are not authorised to perform this action.',
   FORBIDDEN: 'You do not have permission to access this resource.',
   VALIDATION_ERROR: 'Please check your input and try again.',


### PR DESCRIPTION
## Summary

- Detect Supabase "User already registered" in `apiSignUp` and surface a specific `AUTH_EMAIL_ALREADY_EXISTS` error code instead of falling through to the generic INTERNAL_ERROR mask
- `SignUpForm` renders: "An account with this email already exists. [Sign in instead]." with a role-aware link to `/login?type=customer|operator`
- Created `PILGRIMCOMPARE_KNOWLEDGE_BASE.md` with section 5 Technical State (test baseline: 1,830 unit / 19 E2E / build + tsc clean)
- `AI_NOTES.md` §29 + `STATUS.md` health date updated

## Files changed

| File | Change |
|---|---|
| `lib/errors.ts` | Add `AUTH_EMAIL_ALREADY_EXISTS` code |
| `lib/auth/api.ts` | Detect duplicate email from Supabase, throw typed AppError |
| `components/auth/SignUpForm.tsx` | Render linked error message on `AUTH_EMAIL_ALREADY_EXISTS` |
| `PILGRIMCOMPARE_KNOWLEDGE_BASE.md` | Created — section 5 Technical State |
| `AI_NOTES.md` / `STATUS.md` | Docs updated |

## Test plan

- [ ] 1,830/1,830 Vitest passing ✅
- [ ] `npx tsc --noEmit` clean ✅
- [ ] Attempt signup with an already-registered email — expect "An account with this email already exists. Sign in instead." with a working link
- [ ] Attempt signup with a new email — expect normal flow unaffected
- [ ] All other signup error states (weak password, rate limit, network) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)