### PR TITLE
fix: signup duplicate-email 500 + PKCE confirm link (real root causes)

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1286,3 +1286,44 @@ Already implemented in prior work — `Header.tsx` line 231 wraps both Logo + Wo
 
 ### Knowledge Base
 Created `PILGRIMCOMPARE_KNOWLEDGE_BASE.md` (root) with section 5 Technical State — 1,830 unit / 19 E2E passing / 2 skipped / build + tsc clean.
+
+## 31. Signup duplicate-email 500 + PKCE confirm link — real root causes — 2026-06-14
+
+**Branch:** `fix/signup-duplicate-and-pkce-confirm` → dev → main
+**Tests:** 1,833/1,833 pass (28 files, +3 new) · `tsc --noEmit` clean · `npm run build` clean.
+
+Both bugs from §30 were still broken **in production** after PR #74. The §30 fix
+targeted the wrong Supabase behaviour. Real root causes below.
+
+### Bug 1 — duplicate email shows 500 "Something went wrong" (not the friendly 409)
+- **Root cause: Supabase anti-enumeration.** With "Confirm email" **enabled**,
+  `auth.signUp()` on an already-registered email returns **`error: null`** and an
+  obfuscated `data.user` whose **`identities` array is empty**. The `error.code`
+  check from §30/PR #74 never fired (there is no error). Code fell into the
+  service-role block, called `admin.auth.admin.updateUserById()` on the fake user,
+  which threw → masked to `INTERNAL_ERROR` (500) → "Something went wrong".
+- **Fix (`lib/auth/api.ts`):** after `signUp`, if `data.user.identities.length === 0`,
+  throw `AppError({ code: 'AUTH_EMAIL_ALREADY_EXISTS', status: 409 })` **before** the
+  service-role block. The `error.code` / message checks are kept as a fallback for
+  the confirmation-disabled case.
+- **Proof:** `tests/auth-signup-duplicate.test.ts` — 3 tests mock the Supabase
+  clients and assert (a) error-code path → 409, (b) empty-identities path → 409 and
+  `updateUserById` is NOT called, (c) genuine signup (non-empty identities) → role
+  written. Deterministic; no live email needed.
+
+### Bug 2 — confirm link → "Verification link invalid or expired"
+- **Root cause: PKCE flow.** `@supabase/ssr` defaults to `flowType: 'pkce'`. The
+  confirmation email's `ConfirmationURL` routes through Supabase's `/auth/v1/verify`
+  endpoint, which redirects to **`/auth/confirm?code=<auth_code>`**. The old route
+  only handled `?token_hash=&type=`, found neither, and fell straight through to the
+  `invalid_link` redirect — failed 100% of the time.
+- **Fix (`app/auth/confirm/route.ts`):** handle **both** callback shapes —
+  `code` → `exchangeCodeForSession(code)` (PKCE), and `token_hash`+`type` →
+  `verifyOtp()` (OTP template). Session cookies written onto the redirect response
+  as before.
+- **Caveat (PKCE, inherent):** `exchangeCodeForSession` needs the `code_verifier`
+  cookie set on the *same browser* during `signUp`. Same-device works; cross-device
+  (sign up desktop, open email on phone) does not. For cross-device robustness,
+  switch the Supabase "Confirm signup" email template URL to:
+  `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup` — the route
+  already supports that path via `verifyOtp`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 > **Single rolling tracker.** Any AI/dev: read this for current state. Update it after work is **done + tested + verified** (see `CLAUDE.md` rule).
 > Detailed handover lives in `AI_NOTES.md`. Cold-start brief: `HANDOFF.md`. Business: `BUSINESS.md`.
 
-**Last verified:** 2026-06-14 (duplicate email error, knowledge base) · **Branch:** `dev` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
+**Last verified:** 2026-06-14 (signup duplicate-email 500 + PKCE confirm link — real fixes) · **Branch:** `dev` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
 
 ---
 
@@ -11,7 +11,7 @@
 
 | Check | State |
 | --- | --- |
-| `npm run test` | ✅ 1,830/1,830 pass (27 files) |
+| `npm run test` | ✅ 1,833/1,833 pass (28 files) |
 | `npm run build` | ✅ 0 errors |
 | `npx tsc --noEmit` | ✅ pass |
 | E2E `e2e/operator.spec.ts` | ✅ 30/30 pass (chromium + firefox + webkit) |
@@ -132,7 +132,8 @@
 | Homepage redesign — audience routing + live compare preview | ✅ Done 2026-06-13 (PR #63 → dev) | — |
 | Data integrity — "Not provided" for missing hotel name/stars (cards, JSON-LD, quote prefill) | ✅ Done 2026-06-13 (PR #64 → dev, see AI_NOTES §27) | — |
 | Operator form — no silent defaults for skipped stars/distance/group type | ✅ Done 2026-06-13 (PR → dev pending, see AI_NOTES §28) | — |
-| Duplicate email signup shows specific error with sign-in link | ✅ Done 2026-06-14 (dev, see AI_NOTES §29) | — |
+| Duplicate email signup shows specific error with sign-in link | ✅ Done 2026-06-14 (real fix: empty-identities detection, AI_NOTES §31) | — |
+| Email confirm link signs user in (PKCE `code` callback) | ✅ Done 2026-06-14 (AI_NOTES §31) | — |
 | Inclusions three-state model (included / not / not specified) | ⏳ Not started | Follow-up to §28 |
 | Distance vocabulary reconciliation (enum vs wizard vs DB '0-500m') | ⏳ Not started | Separate task (flagged §28) |
 | Existing-data cleanup — null out seed default stars/distance/group | ⏳ Not started | Separate task (flagged §28) |

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -2,62 +2,83 @@ import { type EmailOtpType } from '@supabase/supabase-js';
 import { type NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 
-// Handles the magic link / OTP callback from Supabase confirmation emails.
-// Supabase sends users to: /auth/confirm?token_hash=...&type=signup&next=/
+// Handles the confirmation callback from Supabase signup/recovery emails.
+//
+// Supabase can call this route in TWO different formats depending on the email
+// template and auth flow:
+//
+//   1. PKCE flow (the default for @supabase/ssr): the email's ConfirmationURL
+//      routes through Supabase's /auth/v1/verify endpoint, which then redirects
+//      here as  /auth/confirm?code=<auth_code>  . We exchange that code for a
+//      session with exchangeCodeForSession(). This requires the code_verifier
+//      cookie that was set on this browser during signUp().
+//
+//   2. OTP / token_hash flow (when the email template uses {{ .TokenHash }}):
+//      Supabase redirects here as  /auth/confirm?token_hash=...&type=signup  .
+//      We verify it with verifyOtp().
+//
+// We support BOTH so the confirmation link works regardless of template config.
 //
 // IMPORTANT: We do NOT use `await cookies()` + createClient() here because
 // NextResponse.redirect() creates a fresh response that won't inherit cookies
 // written via the Next.js cookieStore. Instead we use createServerClient
 // directly with a custom setAll handler that writes cookies onto the redirect
-// response itself.
+// response itself, so the session is established on the client.
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get('code');
   const token_hash = searchParams.get('token_hash');
   const type = searchParams.get('type') as EmailOtpType | null;
   const next = searchParams.get('next') ?? '/';
 
-  if (token_hash && type) {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-    if (!url || !anonKey) {
-      return NextResponse.redirect(new URL('/verify-email?error=config_error', origin));
-    }
-
-    // Collect cookies that verifyOtp wants to set, then apply them to the
-    // redirect response so the session is established on the client.
-    const pendingCookies: Array<{ name: string; value: string; options: Record<string, unknown> }> = [];
-
-    const supabase = createServerClient(url, anonKey, {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet) {
-          pendingCookies.push(...cookiesToSet);
-        },
-      },
-    });
-
-    const { error } = await supabase.auth.verifyOtp({ type, token_hash });
-
-    if (!error) {
-      const { data: { user } } = await supabase.auth.getUser();
-      const role = user?.app_metadata?.role;
-      const destination = role === 'operator' && next === '/' ? '/operator/onboarding' : next;
-      const redirectUrl = new URL(destination, origin);
-      redirectUrl.searchParams.set('verified', '1');
-
-      const response = NextResponse.redirect(redirectUrl);
-
-      // Apply session cookies from verifyOtp directly onto the redirect response
-      pendingCookies.forEach(({ name, value, options }) => {
-        response.cookies.set(name, value, options as Parameters<typeof response.cookies.set>[2]);
-      });
-
-      return response;
-    }
+  if (!url || !anonKey) {
+    return NextResponse.redirect(new URL('/verify-email?error=config_error', origin));
   }
 
-  return NextResponse.redirect(new URL('/verify-email?error=invalid_link', origin));
+  // Only act if we actually received a confirmation payload.
+  if (!code && !(token_hash && type)) {
+    return NextResponse.redirect(new URL('/verify-email?error=invalid_link', origin));
+  }
+
+  // Collect cookies that the auth call wants to set, then apply them to the
+  // redirect response so the session is established on the client.
+  const pendingCookies: Array<{ name: string; value: string; options: Record<string, unknown> }> = [];
+
+  const supabase = createServerClient(url, anonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        pendingCookies.push(...cookiesToSet);
+      },
+    },
+  });
+
+  // Run whichever flow matches the params we received.
+  const { error } = code
+    ? await supabase.auth.exchangeCodeForSession(code)
+    : await supabase.auth.verifyOtp({ type: type!, token_hash: token_hash! });
+
+  if (error) {
+    return NextResponse.redirect(new URL('/verify-email?error=invalid_link', origin));
+  }
+
+  const { data: { user } } = await supabase.auth.getUser();
+  const role = user?.app_metadata?.role;
+  const destination = role === 'operator' && next === '/' ? '/operator/onboarding' : next;
+  const redirectUrl = new URL(destination, origin);
+  redirectUrl.searchParams.set('verified', '1');
+
+  const response = NextResponse.redirect(redirectUrl);
+
+  // Apply session cookies from the auth call directly onto the redirect response.
+  pendingCookies.forEach(({ name, value, options }) => {
+    response.cookies.set(name, value, options as Parameters<typeof response.cookies.set>[2]);
+  });
+
+  return response;
 }

--- a/lib/auth/api.ts
+++ b/lib/auth/api.ts
@@ -25,10 +25,11 @@ export async function apiSignUp(input: SignUpInput) {
     email: input.email,
     password: input.password,
     options: {
-        // emailRedirectTo ensures the confirmation email links to /auth/confirm, which
-        // calls verifyOtp and sets session cookies on the redirect response. Without
-        // this, Supabase falls back to the dashboard Site URL (homepage) and the
-        // session is never established after the user clicks the confirmation link.
+        // emailRedirectTo ensures the confirmation email links back to /auth/confirm,
+        // which establishes the session (exchangeCodeForSession for PKCE, or verifyOtp
+        // for token_hash) and sets cookies on the redirect response. Without this,
+        // Supabase falls back to the dashboard Site URL (homepage) and the session is
+        // never established after the user clicks the confirmation link.
         emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/confirm`,
         // NOTE: role is deliberately NOT stored in user_metadata. user_metadata is
         // editable by the user via supabase.auth.updateUser({ data }), so trusting it
@@ -53,6 +54,18 @@ export async function apiSignUp(input: SignUpInput) {
       throw new AppError({ code: 'AUTH_EMAIL_ALREADY_EXISTS', status: 409 });
     }
     throw new Error(error.message);
+  }
+
+  // ANTI-ENUMERATION: when "Confirm email" is enabled, Supabase does NOT return
+  // an error for an already-registered email. To prevent email enumeration it
+  // returns error=null plus an obfuscated user whose `identities` array is empty
+  // (a real new signup always has at least one identity). We must detect this
+  // here — otherwise the code below tries to updateUserById() on the fake user
+  // and throws a 500 ("Something went wrong"). Treat empty identities as a
+  // duplicate and surface the friendly AUTH_EMAIL_ALREADY_EXISTS message.
+  // See: https://supabase.com/docs/reference/javascript/auth-signup
+  if (data.user && Array.isArray(data.user.identities) && data.user.identities.length === 0) {
+    throw new AppError({ code: 'AUTH_EMAIL_ALREADY_EXISTS', status: 409 });
   }
 
   // SECURITY: write the authorization role to app_metadata, which only the service

--- a/tests/auth-signup-duplicate.test.ts
+++ b/tests/auth-signup-duplicate.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AppError } from '../lib/errors';
+
+// Mocks for the two Supabase clients apiSignUp depends on.
+const signUpMock = vi.fn();
+const updateUserByIdMock = vi.fn();
+
+vi.mock('../lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { signUp: signUpMock },
+  })),
+}));
+
+vi.mock('../lib/supabase/service-role', () => ({
+  createServiceRoleClient: vi.fn(() => ({
+    auth: { admin: { updateUserById: updateUserByIdMock } },
+  })),
+}));
+
+import { apiSignUp } from '../lib/auth/api';
+
+const validInput = {
+  email: 'existing@example.com',
+  password: 'Password1!',
+  role: 'customer' as const,
+  name: 'Existing User',
+};
+
+describe('apiSignUp — duplicate email detection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: role write succeeds (only reached on the happy path).
+    updateUserByIdMock.mockResolvedValue({ error: null });
+    process.env.FEATURE_USE_REAL_DB = 'false';
+  });
+
+  it('throws AUTH_EMAIL_ALREADY_EXISTS when Supabase returns an error code (confirmation disabled)', async () => {
+    signUpMock.mockResolvedValue({
+      data: { user: null },
+      error: { code: 'user_already_exists', message: 'User already registered' },
+    });
+
+    await expect(apiSignUp(validInput)).rejects.toMatchObject({
+      code: 'AUTH_EMAIL_ALREADY_EXISTS',
+    });
+  });
+
+  it('throws AUTH_EMAIL_ALREADY_EXISTS when Supabase returns empty identities (confirmation enabled, anti-enumeration)', async () => {
+    // This is the production case: "Confirm email" is ON, so Supabase returns
+    // error=null and an obfuscated user with identities: [] for a known email.
+    signUpMock.mockResolvedValue({
+      data: {
+        user: {
+          id: '00000000-0000-0000-0000-000000000000',
+          email: validInput.email,
+          identities: [],
+          user_metadata: {},
+        },
+        session: null,
+      },
+      error: null,
+    });
+
+    await expect(apiSignUp(validInput)).rejects.toBeInstanceOf(AppError);
+    await expect(apiSignUp(validInput)).rejects.toMatchObject({
+      code: 'AUTH_EMAIL_ALREADY_EXISTS',
+      status: 409,
+    });
+
+    // Critically: we must NOT have called updateUserById on the fake user
+    // (that is what previously threw the 500 "Something went wrong").
+    expect(updateUserByIdMock).not.toHaveBeenCalled();
+  });
+
+  it('proceeds to write the role for a genuine new signup (non-empty identities)', async () => {
+    signUpMock.mockResolvedValue({
+      data: {
+        user: {
+          id: '11111111-1111-1111-1111-111111111111',
+          email: 'brand-new@example.com',
+          identities: [{ id: 'abc', provider: 'email' }],
+          user_metadata: { name: 'Brand New' },
+        },
+        session: null,
+      },
+      error: null,
+    });
+
+    const result = await apiSignUp({ ...validInput, email: 'brand-new@example.com' });
+
+    expect(updateUserByIdMock).toHaveBeenCalledWith(
+      '11111111-1111-1111-1111-111111111111',
+      { app_metadata: { role: 'customer' } },
+    );
+    expect(result.user?.id).toBe('11111111-1111-1111-1111-111111111111');
+  });
+});


### PR DESCRIPTION
## Why PR #74 didn't fix it

Both bugs were still live in production. PR #74 targeted the wrong Supabase behaviour.

### Bug 1 — duplicate email shows 500 "Something went wrong"
**Root cause:** Supabase anti-enumeration. With "Confirm email" enabled, `signUp()` on an already-registered email returns `error: null` plus a fake `data.user` with an **empty `identities` array** — no error is thrown. The `error.code` check from #74 never fired; the code then called `updateUserById()` on the fake user → 500.

**Fix:** detect `data.user.identities.length === 0` → throw `AUTH_EMAIL_ALREADY_EXISTS` (409) before the service-role block.

### Bug 2 — confirm link "invalid or expired"
**Root cause:** `@supabase/ssr` defaults to PKCE. The email redirects to `/auth/confirm?code=...`, but the route only handled `?token_hash=&type=` → fell through to `invalid_link` 100% of the time.

**Fix:** handle both — `code` → `exchangeCodeForSession`, `token_hash` → `verifyOtp`.

## Proof
- `tests/auth-signup-duplicate.test.ts` (+3) reproduces the exact empty-identities production case and asserts 409 + no `updateUserById` call.
- 1,833/1,833 tests pass · `tsc --noEmit` clean · `npm run build` clean.

## Follow-up (cross-device confirm)
PKCE needs the same browser that signed up. For cross-device robustness, switch the Supabase "Confirm signup" email template URL to `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup` — this route already supports that path.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)