### PR TITLE
fix: mobile-nav/cookie-banner overlap, signup copy, light-theme Accept button, FAQ spacing

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1327,3 +1327,35 @@ targeted the wrong Supabase behaviour. Real root causes below.
   switch the Supabase "Confirm signup" email template URL to:
   `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup` — the route
   already supports that path via `verifyOtp`.
+
+## 32. Cookie banner / mobile-nav overlap + signup duplicate-email copy — 2026-06-14
+
+**Branch:** `fix/cookie-banner-nav-overlap-signin-copy` → dev → main
+**Tests:** 1,833/1,833 pass (28 files) · `tsc --noEmit` clean · `npm run build` clean.
+UI-only; no logic touched. Verified in browser preview at 390px + desktop.
+
+### Task 1 — cookie banner covered mobile drawer nav items
+- **Root cause: stacking-context trap.** `components/layout/Header.tsx` renders
+  `<header>` with `position: sticky; z-index: 50` (`header.module.css:3-5`), which
+  **creates a stacking context**. The mobile overlay (z-60) and drawer (z-70) live
+  *inside* that context, so their z-index only ranks them within the header — the
+  whole header still sits at root z-50. `CookieConsent` is a **sibling rendered
+  after `<Header>`** in `app/layout.tsx` and was also `z-50` at root → equal z-index,
+  later in DOM → painted **on top of** the drawer, covering the bottom nav items
+  ("Sign in" / "Create account").
+- **Fix (`components/compliance/CookieConsent.tsx`):** banner `z-50` → `z-40`. Now
+  the entire header context (drawer included) ranks above the banner; when the drawer
+  opens it covers the banner. One-class change, lowest risk.
+- **Desktop unchanged:** the sticky header (top) and banner (bottom) never overlap
+  spatially, so z-40 vs z-50 makes no visible difference — verified at desktop width.
+
+### Task 2 — duplicate-email "Sign in instead" copy was dismissive/ambiguous
+- **Context already available:** `SignUpForm` holds `role` state (`'customer'|'operator'`),
+  seeded from the `?type=` URL param. The duplicate-email link was **already**
+  type-specific (`/login?type=operator` vs `/login?type=customer`) from §30/§31 work —
+  only the wording needed fixing.
+- **Fix (`components/auth/SignUpForm.tsx`):** message rewritten to
+  "Looks like you already have an account. **Sign in to your {operator|traveller}
+  account** to continue." — link text is the destination-aware phrase, no em dashes,
+  short, obvious. "traveller" matches the signup tab label (the customer tab reads
+  "Traveller"). No change to 409 detection (`lib/auth/api.ts`) or route logic.

--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1359,3 +1359,25 @@ UI-only; no logic touched. Verified in browser preview at 390px + desktop.
   account** to continue." — link text is the destination-aware phrase, no em dashes,
   short, obvious. "traveller" matches the signup tab label (the customer tab reads
   "Traveller"). No change to 409 detection (`lib/auth/api.ts`) or route logic.
+
+### Task 3 — light-theme cookie "Accept" button was muddy/low-contrast
+- **Root cause:** the Accept button hardcoded `bg-[var(--yellow)] text-black`. In
+  light theme `--yellow` resolves to **`#8A6800`** (dark olive — see
+  `styles/tokens.css:101`), so the primary cookie action rendered muddy brown with
+  black text: low contrast, not prominent.
+- **Fix (`components/compliance/CookieConsent.tsx`):** switch the Accept button to
+  the theme CTA token — `bg-[var(--primary)] text-[var(--color-text-on-brand)]`
+  (border to match). `--primary` = `#FFD31D` (dark) / `#0A6937` green (light);
+  `--color-text-on-brand` = `#000` (dark) / `#F9FAFB` (light). Result: **dark
+  unchanged** (yellow + black), **light = brand green + near-white (~6.5:1, AA)**,
+  consistent with the site "Compare packages" CTA. Removed the hardcoded
+  `rgba(255,211,29,…)` shadow ring (a light-mode token violation).
+
+### Task 4 — "Common questions" to "Ready to compare?" had a disproportionate gap
+- **Root cause:** `FAQ` and `HomeCTA` are two consecutive `.section`s, each with
+  `padding: 3.5rem` top+bottom (`components/marketing/home.module.css`). Stacked,
+  that doubled into a ~7rem (~156px card-to-card) void after a short 2-card FAQ.
+- **Fix:** added `.sectionTightTop { padding-top: 0 }` and applied it to the
+  closing `HomeCTA` section so it hugs the FAQ above it (one section's rhythm,
+  ~100px card-to-card) instead of doubling. Closing CTA reads as the natural next
+  step after the questions, in both themes.

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 > **Single rolling tracker.** Any AI/dev: read this for current state. Update it after work is **done + tested + verified** (see `CLAUDE.md` rule).
 > Detailed handover lives in `AI_NOTES.md`. Cold-start brief: `HANDOFF.md`. Business: `BUSINESS.md`.
 
-**Last verified:** 2026-06-14 (signup duplicate-email 500 + PKCE confirm link — real fixes) · **Branch:** `dev` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
+**Last verified:** 2026-06-14 (cookie-banner / mobile-nav overlap + signup duplicate-email copy) · **Branch:** `dev` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
 
 ---
 
@@ -134,6 +134,8 @@
 | Operator form — no silent defaults for skipped stars/distance/group type | ✅ Done 2026-06-13 (PR → dev pending, see AI_NOTES §28) | — |
 | Duplicate email signup shows specific error with sign-in link | ✅ Done 2026-06-14 (real fix: empty-identities detection, AI_NOTES §31) | — |
 | Email confirm link signs user in (PKCE `code` callback) | ✅ Done 2026-06-14 (AI_NOTES §31) | — |
+| Cookie banner no longer covers mobile drawer nav items | ✅ Done 2026-06-14 (z-index stacking-context fix, AI_NOTES §32) | — |
+| Signup duplicate-email copy clearer + type-aware sign-in link | ✅ Done 2026-06-14 (UI copy, AI_NOTES §32) | — |
 | Inclusions three-state model (included / not / not specified) | ⏳ Not started | Follow-up to §28 |
 | Distance vocabulary reconciliation (enum vs wizard vs DB '0-500m') | ⏳ Not started | Separate task (flagged §28) |
 | Existing-data cleanup — null out seed default stars/distance/group | ⏳ Not started | Separate task (flagged §28) |

--- a/STATUS.md
+++ b/STATUS.md
@@ -136,6 +136,8 @@
 | Email confirm link signs user in (PKCE `code` callback) | ✅ Done 2026-06-14 (AI_NOTES §31) | — |
 | Cookie banner no longer covers mobile drawer nav items | ✅ Done 2026-06-14 (z-index stacking-context fix, AI_NOTES §32) | — |
 | Signup duplicate-email copy clearer + type-aware sign-in link | ✅ Done 2026-06-14 (UI copy, AI_NOTES §32) | — |
+| Light-theme cookie "Accept" button prominent + readable (brand green) | ✅ Done 2026-06-14 (token fix, AI_NOTES §32) | — |
+| "Common questions" → closing CTA spacing tightened (both themes) | ✅ Done 2026-06-14 (AI_NOTES §32) | — |
 | Inclusions three-state model (included / not / not specified) | ⏳ Not started | Follow-up to §28 |
 | Distance vocabulary reconciliation (enum vs wizard vs DB '0-500m') | ⏳ Not started | Separate task (flagged §28) |
 | Existing-data cleanup — null out seed default stars/distance/group | ⏳ Not started | Separate task (flagged §28) |

--- a/components/auth/SignUpForm.tsx
+++ b/components/auth/SignUpForm.tsx
@@ -242,14 +242,14 @@ export function SignUpForm() {
         >
           {isDuplicateEmail ? (
             <>
-              An account with this email already exists.{' '}
+              Looks like you already have an account.{' '}
               <Link
                 href={role === 'operator' ? '/login?type=operator' : '/login?type=customer'}
                 className="underline font-medium"
               >
-                Sign in instead
-              </Link>
-              .
+                Sign in to your {role === 'operator' ? 'operator' : 'traveller'} account
+              </Link>{' '}
+              to continue.
             </>
           ) : (
             error

--- a/components/compliance/CookieConsent.tsx
+++ b/components/compliance/CookieConsent.tsx
@@ -133,7 +133,7 @@ export function CookieConsent() {
             </button>
             <button
               onClick={handleAcceptAll}
-              className="min-h-[44px] rounded-md border border-[var(--yellow)] bg-[var(--yellow)] px-4 py-2 text-sm font-semibold text-black shadow-[0_0_0_1px_rgba(255,211,29,0.25)] hover:brightness-95"
+              className="min-h-[44px] rounded-md border border-[var(--primary)] bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-[var(--color-text-on-brand)] hover:brightness-95"
               data-testid="cookie-accept-all"
             >
               Accept

--- a/components/compliance/CookieConsent.tsx
+++ b/components/compliance/CookieConsent.tsx
@@ -66,7 +66,7 @@ export function CookieConsent() {
       aria-label="Cookie consent"
       aria-modal="true"
       data-testid="cookie-consent-banner"
-      className="fixed bottom-0 left-0 right-0 z-50 border-t border-[var(--borderSubtle)] bg-[var(--surfaceDark)] p-4 shadow-2xl"
+      className="fixed bottom-0 left-0 right-0 z-40 border-t border-[var(--borderSubtle)] bg-[var(--surfaceDark)] p-4 shadow-2xl"
     >
       <div className="mx-auto max-w-6xl">
         <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">

--- a/components/marketing/HomeCTA.tsx
+++ b/components/marketing/HomeCTA.tsx
@@ -8,7 +8,7 @@ import styles from './home.module.css'
  */
 export function HomeCTA() {
   return (
-    <section className={styles.section} aria-labelledby="home-cta-heading">
+    <section className={`${styles.section} ${styles.sectionTightTop}`} aria-labelledby="home-cta-heading">
       <div className={styles.ctaCard}>
         <h2 id="home-cta-heading" className={styles.ctaCardTitle}>
           Ready to compare?

--- a/components/marketing/home.module.css
+++ b/components/marketing/home.module.css
@@ -8,6 +8,12 @@
   box-sizing: border-box;
 }
 
+/* Closing CTA hugs the section above it (e.g. FAQ) instead of doubling
+   the 3.5rem section padding into a ~7rem void. */
+.sectionTightTop {
+  padding-top: 0;
+}
+
 .sectionHead {
   max-width: 640px;
   margin-bottom: 2rem;


### PR DESCRIPTION
Four small UX fixes. UI only — no logic / auth-detection / route changes.

## 1. Cookie banner covered mobile drawer nav items
`<header>` is `sticky; z-index:50` → creates a stacking context, trapping the overlay (z-60) and drawer (z-70) at root z-50. `CookieConsent` was a later root sibling at z-50, so it painted over the drawer. **Fix:** banner → `z-40`. Verified at 390px (all drawer items tappable) and desktop (no spatial overlap → unchanged).

## 2. Duplicate-email signup copy was dismissive/ambiguous
Link destination was already type-specific via `role` state. **Fix:** copy rewritten to "Looks like you already have an account. **Sign in to your operator/traveller account** to continue." No em dashes; 409 detection in `lib/auth/api.ts` untouched.

## 3. Light-theme cookie "Accept" button muddy / low-contrast
`--yellow` = `#8A6800` (dark olive) in light theme, so Accept rendered muddy brown. **Fix:** use the theme CTA token `bg-[var(--primary)] text-[var(--color-text-on-brand)]`. Dark stays yellow+black; light is brand green + near-white (~6.5:1, AA), matching the site CTA. Removed a hardcoded `rgba(255,211,29,…)` shadow ring.

## 4. "Common questions" → "Ready to compare?" disproportionate gap
`FAQ` + `HomeCTA` were two consecutive `.section`s (each `padding: 3.5rem`), doubling to ~7rem after a short FAQ. **Fix:** `.sectionTightTop { padding-top: 0 }` on the closing CTA so it hugs the FAQ. Both themes.

## CI
- `npm run test` ✅ 1,833/1,833 (28 files)
- `npx tsc --noEmit` ✅
- `npm run build` ✅ 0 errors
- Browser-verified at 390px + desktop, light + dark.

Docs: AI_NOTES §32, STATUS.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)