### PR TITLE
Release: packages UX redesign, CSP nonce, light-theme bg, compare-bar stability + polish

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -12,6 +12,22 @@ This file is the current handover source of truth. If another document conflicts
 
 ---
 
+## §UX/CSP/theme polish — 2026-06-14 (branch `fix/packages-ux-csp-light-theme`)
+
+Six recurring issues fixed in one branch, all browser-verified (light+dark, mobile 375px + desktop):
+
+1. **`/packages` redesign** — `components/packages/PackagesBrowse.tsx` was raw Tailwind with `<select>`s and bland cards. Rewritten to reuse the gold-standard `PackageCard` + `CompareBar` + comparison `Dialog` from `/search` (via `toSearchDisplay()` mapper) so both routes share one card language. New toolbar: segmented pilgrimage-type control (primary filter), season/sort selects, Saved chip. New stylesheet `components/packages/packagesBrowse.module.css` (token-only). Compare-first flow (select 2–3 → sticky bar → side-by-side table) now matches `/search`.
+   - **Test contracts:** unit `tests/packages-browse.test.tsx` unchanged (shortlist-filter / shortlist-count / shortlist-empty kept on the page; shortlist-toggle-* + package-card-* now come from `PackageCard`). `e2e/catalogue.spec.ts` updated: `package-compare-checkbox-*`→`package-compare-toggle-*`, `packages-compare-button`→`search-compare-button` (only visible after ≥1 selected), `package-link-*`→`package-view-*`.
+2. **CSP inline-script block** — the flash-prevent theme `<script>` in `app/layout.tsx` had no nonce, so the strict `script-src 'self' 'nonce-…'` (no `unsafe-inline`) blocked it. Now reads `x-nonce` from `headers()` and sets `nonce={nonce}`. (`JsonLdScript` already nonces itself; Next's own scripts inherit the middleware nonce.)
+3. **Light-theme background** — `app/globals.css` previously set `background-image:none` in light. Now keeps the base kaaba SVG and only swaps `background-color`; `body::before` lays a ~0.93 ivory wash so the architecture reads as a faint ghost without hurting text contrast (content sits at z-index:1).
+4. **FAQ→CTA gap** — `sectionTightTop`'s `padding-top:0` was being clobbered on mobile by the `@media(max-width:768px) .section{padding:…}` shorthand. Re-zeroed inside the media query + small negative pull. Gap now ~20px both breakpoints.
+5. **Mobile sort crop** — `/search` `.sortDropdown` was right-anchored; when the controls wrap to a left-aligned row on mobile it overflowed the left viewport edge. Added `@media(max-width:768px)` → `left:0; right:auto; max-width:calc(100vw-1.5rem)`.
+6. **Header IA** — decision: **no separate Home link.** Logo already links `/` (universal convention); a second link is redundant clutter.
+
+Test/build baseline unchanged: 1,833 unit tests pass, `tsc` clean, `npm run build` 0 errors.
+
+---
+
 ## 0. Gate Status
 
 ### Gate 1 — Safe to merge dev → main ✅ DONE

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 > **Single rolling tracker.** Any AI/dev: read this for current state. Update it after work is **done + tested + verified** (see `CLAUDE.md` rule).
 > Detailed handover lives in `AI_NOTES.md`. Cold-start brief: `HANDOFF.md`. Business: `BUSINESS.md`.
 
-**Last verified:** 2026-06-14 (cookie-banner / mobile-nav overlap + signup duplicate-email copy) · **Branch:** `dev` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
+**Last verified:** 2026-06-14 (packages UX redesign + CSP nonce + light-theme bg + FAQ gap + mobile sort crop) · **Branch:** `fix/packages-ux-csp-light-theme` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
 
 ---
 
@@ -23,6 +23,8 @@
 ## ✅ Done (shipped & verified)
 
 **Traveller flow**
+- **`/packages` browse redesign (2026-06-14, branch `fix/packages-ux-csp-light-theme`):** rewritten to reuse the polished `PackageCard` + sticky `CompareBar` + comparison dialog from `/search` (one consistent card language, low cognitive load). Segmented pilgrimage-type control, clean season/sort selects, Saved chip. Verified light + dark, mobile + desktop; compare 2→table flow works. Unit tests preserved; `e2e/catalogue.spec.ts` testids updated to the shared contracts.
+- **Cross-cutting polish (same branch):** CSP nonce now applied to the inline theme script in `app/layout.tsx` (fixes `script-src` inline-execution block); light theme re-shows the kaaba SVG as a faint ghost under an ivory wash (readability-safe); FAQ→CTA homepage gap tightened to ~20px (mobile media-query was clobbering `sectionTightTop` padding); mobile sort dropdown on `/search/packages` no longer crops (left-anchored + viewport-clamped ≤768px). **Header IA decision:** no separate "Home" link — the logo already links home (universal convention); a second link adds clutter without discoverability gain.
 - Package discovery: browse, sort, filter (budget, dates, hotel stars, Haram distance, flight type)
 - Umrah 4-step search form (date picker, traveller stepper, star select, budget slider)
 - Airport-level routing: LHR, LGW, BHX, MAN (departure + return), backend filters by airport code

--- a/app/globals.css
+++ b/app/globals.css
@@ -34,15 +34,18 @@ body::before {
   pointer-events: none;
 }
 
-/* Light theme: clean warm-ivory gradient — no architectural overlay competing with content */
+/* Light theme: keep the same kaaba silhouette as dark mode, but barely-there.
+   We reuse the base body's background-image (the SVG) and only swap the base
+   colour, then let body::before lay a heavy warm-ivory wash over it so the
+   architecture reads as a faint atmospheric ghost — never enough contrast to
+   interfere with text (all content sits at z-index:1, above the overlay). */
 [data-theme="light"] body {
-  background: linear-gradient(160deg, #F8F6F1 0%, #EDE8DC 55%, #F4F0E7 100%);
-  background-image: none;
-  background-attachment: initial;
+  background-color: #EDE8DC;
 }
 
 [data-theme="light"] body::before {
-  display: none;
+  display: block;
+  background: linear-gradient(160deg, rgba(248, 246, 241, 0.93) 0%, rgba(237, 232, 220, 0.93) 55%, rgba(244, 240, 231, 0.93) 100%);
 }
 
 /* Light theme: prophetic green scrollbar thumb, warm-stone track */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { CookieConsent } from "@/components/compliance/CookieConsent";
 import { JsonLdScript, graphJsonLd, organizationJsonLd, websiteJsonLd } from "@/lib/seo/json-ld";
 import { Repository } from "@/lib/api/repository";
 import { ThemeProvider } from "@/components/theme/ThemeProvider";
+import { headers } from "next/headers";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -47,10 +48,15 @@ export default async function RootLayout({
     // DB unavailable — footer renders without city links
   }
 
+  // Nonce set by middleware CSP. The inline theme script below must carry it,
+  // otherwise the strict 'script-src' nonce policy blocks it (no 'unsafe-inline').
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   return (
     <html lang="en-GB" className={`${exo2Font.variable} ${inter.variable} ${nunito.variable}`} suppressHydrationWarning>
       <head>
         <script
+          nonce={nonce}
           suppressHydrationWarning
           dangerouslySetInnerHTML={{
             __html: `(function(){try{var t=localStorage.getItem('theme');document.documentElement.setAttribute('data-theme',t==='light'?'light':'dark');}catch(e){}})();`,

--- a/components/marketing/home.module.css
+++ b/components/marketing/home.module.css
@@ -8,10 +8,12 @@
   box-sizing: border-box;
 }
 
-/* Closing CTA hugs the section above it (e.g. FAQ) instead of doubling
-   the 3.5rem section padding into a ~7rem void. */
+/* Closing CTA hugs the section above it (e.g. FAQ). Zeroing its own top
+   padding still left the FAQ's 3.5rem bottom padding as a visible void, so we
+   also pull the CTA up into that padding to land on a tight ~1.5rem gap. */
 .sectionTightTop {
   padding-top: 0;
+  margin-top: -2rem;
 }
 
 .sectionHead {
@@ -494,6 +496,14 @@
 @media (max-width: 768px) {
   .section {
     padding: 2.75rem 1rem;
+  }
+
+  /* The shorthand `.section` padding above re-introduces a top padding on
+     mobile, so we must re-zero it here (otherwise the CTA detaches from the
+     FAQ again). Smaller section padding also means a smaller pull. */
+  .sectionTightTop {
+    padding-top: 0;
+    margin-top: -1.5rem;
   }
 
   .cityGrid {

--- a/components/packages/PackagesBrowse.tsx
+++ b/components/packages/PackagesBrowse.tsx
@@ -1,23 +1,29 @@
 'use client'
 
-import Link from 'next/link'
 import { useEffect, useMemo, useState, useTransition } from 'react'
 import type { Package, OperatorProfile } from '@/lib/types'
 import { NEUTRAL_SORT_DISCLOSURE } from '@/lib/content-rules'
 import { mapPackageToComparison, handleComparisonSelection } from '@/lib/comparison'
+import { toSearchDisplay } from '@/components/search/search-utils'
+import PackageCard from '@/components/search/PackageCard'
+import CompareBar, { type CompareBarItem } from '@/components/search/CompareBar'
 import { ComparisonTable } from '@/components/request/ComparisonTable'
-import { CURRENCY_CHANGE_EVENT, getRegionSettings } from '@/lib/i18n/region'
-import { formatPriceForRegion } from '@/lib/i18n/format'
 import {
   Dialog,
+  OverlayBody,
   OverlayContent,
+  OverlayDescription,
   OverlayHeader,
   OverlayTitle,
 } from '@/components/ui/Overlay'
+import styles from './packagesBrowse.module.css'
 
 type PilgrimageFilter = 'all' | 'umrah' | 'hajj'
-type PriceSort = 'none' | 'price-asc' | 'price-desc'
+type SortOption = 'relevance' | 'price-asc' | 'price-desc'
+
 const SHORTLIST_STORAGE_KEY = 'kb_shortlist_packages'
+const COMPARE_MIN = 2
+const COMPARE_MAX = 3
 const uniqueIds = (ids: string[]) => Array.from(new Set(ids))
 
 interface PackagesBrowseProps {
@@ -25,21 +31,32 @@ interface PackagesBrowseProps {
   error?: string
 }
 
-const formatSeasonLabel = (pkg: Package) => pkg.seasonLabel ?? 'Flexible'
+const TYPE_TABS: { value: PilgrimageFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'umrah', label: 'Umrah' },
+  { value: 'hajj', label: 'Hajj' },
+]
+
+const buildInclusions = (pkg: Package) =>
+  [
+    { label: 'Visa', included: pkg.inclusions?.visa ?? false },
+    { label: 'Flights', included: pkg.inclusions?.flights ?? false },
+    { label: 'Transfers', included: pkg.inclusions?.transfers ?? false },
+    { label: 'Meals', included: pkg.inclusions?.meals ?? false },
+  ].filter((chip) => chip.included)
 
 export function PackagesBrowse({ packages, error }: PackagesBrowseProps) {
   const [pilgrimageType, setPilgrimageType] = useState<PilgrimageFilter>('all')
   const [seasonLabel, setSeasonLabel] = useState<string>('all')
-  const [priceSort, setPriceSort] = useState<PriceSort>('none')
+  const [sortBy, setSortBy] = useState<SortOption>('relevance')
   const [isPending, startTransition] = useTransition()
-  const [selectedPackages, setSelectedPackages] = useState<string[]>([])
+  const [selectedCompareIds, setSelectedCompareIds] = useState<string[]>([])
   const [shortlistedPackages, setShortlistedPackages] = useState<string[]>([])
   const [shortlistOnly, setShortlistOnly] = useState(false)
   const [shortlistLoaded, setShortlistLoaded] = useState(false)
   const [operatorsById, setOperatorsById] = useState<Record<string, OperatorProfile>>({})
   const [showComparison, setShowComparison] = useState(false)
   const [compareMessage, setCompareMessage] = useState<string>('')
-  const [regionSettings, setRegionSettings] = useState(() => getRegionSettings())
 
   useEffect(() => {
     fetch('/api/operators')
@@ -48,12 +65,13 @@ export function PackagesBrowse({ packages, error }: PackagesBrowseProps) {
         if (d.operators) {
           setOperatorsById(
             (d.operators as OperatorProfile[]).reduce<Record<string, OperatorProfile>>(
-              (acc, op) => { acc[op.id] = op; return acc; },
+              (acc, op) => { acc[op.id] = op; return acc },
               {}
             )
           )
         }
       })
+      .catch(() => { /* operator trust signals just won't render */ })
   }, [])
 
   useEffect(() => {
@@ -81,17 +99,10 @@ export function PackagesBrowse({ packages, error }: PackagesBrowseProps) {
     }
   }, [shortlistLoaded, shortlistedPackages])
 
-  useEffect(() => {
-    const updateSettings = () => setRegionSettings(getRegionSettings())
-    window.addEventListener(CURRENCY_CHANGE_EVENT, updateSettings)
-    return () => window.removeEventListener(CURRENCY_CHANGE_EVENT, updateSettings)
-  }, [])
-
   const seasonOptions = useMemo(() => {
     const labels = packages
       .map((pkg) => pkg.seasonLabel)
       .filter((label): label is string => Boolean(label))
-
     return Array.from(new Set(labels)).sort()
   }, [packages])
 
@@ -101,291 +112,269 @@ export function PackagesBrowse({ packages, error }: PackagesBrowseProps) {
     if (pilgrimageType !== 'all') {
       next = next.filter((pkg) => pkg.pilgrimageType === pilgrimageType)
     }
-
     if (seasonLabel !== 'all') {
       next = next.filter((pkg) => pkg.seasonLabel === seasonLabel)
     }
-
-    if (priceSort === 'price-asc') {
+    if (sortBy === 'price-asc') {
       next.sort((a, b) => a.pricePerPerson - b.pricePerPerson)
-    }
-
-    if (priceSort === 'price-desc') {
+    } else if (sortBy === 'price-desc') {
       next.sort((a, b) => b.pricePerPerson - a.pricePerPerson)
     }
-
     if (shortlistOnly) {
       next = next.filter((pkg) => shortlistedPackages.includes(pkg.id))
     }
-
     return next
-  }, [packages, pilgrimageType, priceSort, seasonLabel, shortlistOnly, shortlistedPackages])
+  }, [packages, pilgrimageType, seasonLabel, sortBy, shortlistOnly, shortlistedPackages])
 
-  const showEmpty = !error && filteredPackages.length === 0
   const showShortlistEmpty = shortlistOnly && !error && filteredPackages.length === 0
-  const compareDisabled = selectedPackages.length < 2
-  const formatPrice = (pkg: Package) => {
-    const priceInfo = formatPriceForRegion(pkg.pricePerPerson, pkg.currency, regionSettings)
-    return pkg.priceType === 'from' ? `From ${priceInfo.formatted}` : priceInfo.formatted
+  const showEmpty = !error && !showShortlistEmpty && filteredPackages.length === 0
+
+  const onToggleShortlist = (packageId: string) => {
+    setShortlistedPackages((prev) =>
+      uniqueIds(
+        prev.includes(packageId) ? prev.filter((id) => id !== packageId) : [...prev, packageId]
+      )
+    )
   }
+
+  const onToggleCompare = (packageId: string) => {
+    setCompareMessage('')
+    setSelectedCompareIds((prev) => {
+      try {
+        return handleComparisonSelection(prev, packageId)
+      } catch (err) {
+        setCompareMessage((err as Error).message)
+        return prev
+      }
+    })
+  }
+
+  const compareFull = selectedCompareIds.length >= COMPARE_MAX
+
+  // Map from the full list (not the filtered view) so a selected package never
+  // silently drops out of the comparison when filters change.
   const comparisonRows = useMemo(
     () =>
-      filteredPackages
-        .filter((pkg) => selectedPackages.includes(pkg.id))
+      packages
+        .filter((pkg) => selectedCompareIds.includes(pkg.id))
         .map((pkg) => mapPackageToComparison(pkg, operatorsById[pkg.operatorId])),
-    [filteredPackages, operatorsById, selectedPackages]
+    [packages, operatorsById, selectedCompareIds]
   )
+
+  const compareItems = useMemo<CompareBarItem[]>(
+    () =>
+      selectedCompareIds.map((id) => {
+        const pkg = packages.find((p) => p.id === id)
+        const operator = pkg ? operatorsById[pkg.operatorId] : undefined
+        return { id, label: operator?.companyName ?? pkg?.title ?? 'Selected package' }
+      }),
+    [selectedCompareIds, packages, operatorsById]
+  )
+
+  const openComparison = () => {
+    // Defer past the current event tick so the dialog's dismissable layer
+    // doesn't treat this same click as an "outside" click and re-close it.
+    if (selectedCompareIds.length >= COMPARE_MIN) {
+      setTimeout(() => setShowComparison(true), 0)
+    }
+  }
+
+  const resetFilters = () => {
+    startTransition(() => {
+      setPilgrimageType('all')
+      setSeasonLabel('all')
+      setSortBy('relevance')
+      setShortlistOnly(false)
+    })
+  }
 
   return (
     <section
       data-testid="packages-page"
       aria-busy={isPending ? 'true' : 'false'}
-      className="w-full max-w-6xl mx-auto px-4 py-10"
+      className={`${styles.page} ${compareItems.length > 0 ? styles.gridWithBar : ''}`}
     >
-      <header className="mb-8">
-        <h1 className="text-3xl font-semibold text-[var(--text)]">Browse Packages</h1>
-        <p className="mt-2 text-[var(--textMuted)]">
-          Compare published Umrah and Hajj packages from verified operators.
+      <header className={styles.header}>
+        <h1 className={styles.title}>Browse packages</h1>
+        <p className={styles.subtitle}>
+          Compare published Umrah and Hajj packages from verified UK operators — side by side, no
+          cost to you.
         </p>
       </header>
 
-      <div className="grid gap-4 md:grid-cols-3 mb-6">
-        <div className="flex flex-col gap-2">
-          <label htmlFor="packages-filter-type" className="text-sm font-medium text-[var(--text)]">
-            Pilgrimage type
-          </label>
-          <select
-            id="packages-filter-type"
-            data-testid="packages-filter-type"
-            value={pilgrimageType}
-            onChange={(event) =>
-              startTransition(() => setPilgrimageType(event.target.value as PilgrimageFilter))
-            }
-            className="rounded border border-[var(--border)] bg-[var(--panel)] px-3 py-2 text-sm"
-          >
-            <option value="all">All</option>
-            <option value="umrah">Umrah</option>
-            <option value="hajj">Hajj</option>
-          </select>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <label htmlFor="packages-filter-season" className="text-sm font-medium text-[var(--text)]">
-            Season
-          </label>
-          <select
-            id="packages-filter-season"
-            value={seasonLabel}
-            onChange={(event) => startTransition(() => setSeasonLabel(event.target.value))}
-            className="rounded border border-[var(--border)] bg-[var(--panel)] px-3 py-2 text-sm"
-            disabled={seasonOptions.length === 0}
-          >
-            <option value="all">All seasons</option>
-            {seasonOptions.map((label) => (
-              <option key={label} value={label}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <label htmlFor="packages-filter-price" className="text-sm font-medium text-[var(--text)]">
-            Price sort
-          </label>
-          <select
-            id="packages-filter-price"
-            value={priceSort}
-            onChange={(event) =>
-              startTransition(() => setPriceSort(event.target.value as PriceSort))
-            }
-            className="rounded border border-[var(--border)] bg-[var(--panel)] px-3 py-2 text-sm"
-          >
-            <option value="none">No sorting</option>
-            <option value="price-asc">Lowest to highest</option>
-            <option value="price-desc">Highest to lowest</option>
-          </select>
-          <p className="text-xs text-[var(--textMuted)]" data-testid="sort-disclosure">
-            {NEUTRAL_SORT_DISCLOSURE}{' '}
-            <a
-              href="/how-we-rank"
-              className="underline underline-offset-2 hover:text-[var(--text)] focus-visible:outline-2 focus-visible:outline-[var(--yellow)] focus-visible:outline-offset-2"
+      <div className={styles.toolbar}>
+        {/* Primary filter: pilgrimage type as a segmented control */}
+        <div className={styles.segment} role="group" aria-label="Filter by pilgrimage type">
+          {TYPE_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              type="button"
+              data-testid={`packages-type-${tab.value}`}
+              className={`${styles.segmentBtn} ${pilgrimageType === tab.value ? styles.segmentBtnActive : ''}`}
+              aria-pressed={pilgrimageType === tab.value}
+              onClick={() => startTransition(() => setPilgrimageType(tab.value))}
             >
-              How we rank
-            </a>
-          </p>
+              {tab.label}
+            </button>
+          ))}
         </div>
 
-        <div className="flex flex-col gap-2">
-          <span className="text-sm font-medium text-[var(--text)]">Shortlist</span>
-          <label className="flex items-center gap-2 text-sm text-[var(--textMuted)]">
-            <input
-              type="checkbox"
-              data-testid="shortlist-filter"
-              checked={shortlistOnly}
-              onChange={(event) => setShortlistOnly(event.target.checked)}
-              className="h-4 w-4 rounded border-[var(--border)] bg-[var(--panel)] text-[var(--primary)] focus:ring-[var(--primary)]"
-            />
-            Show shortlist only
-          </label>
-          <div
-            data-testid="shortlist-count"
-            className="text-xs font-medium text-[var(--textMuted)]"
-          >
-            {shortlistedPackages.length} shortlisted
+        <div className={styles.controls}>
+          <div className={styles.count} aria-live="polite">
+            <span className={styles.countNumber}>{filteredPackages.length}</span>
+            <span className={styles.countLabel}>
+              {filteredPackages.length === 1 ? 'package' : 'packages'}
+            </span>
           </div>
-        </div>
-      </div>
 
-      <div className="mb-6 flex flex-col gap-2">
-        <button
-          type="button"
-          data-testid="packages-compare-button"
-          onClick={() => setShowComparison(true)}
-          disabled={compareDisabled}
-          aria-disabled={compareDisabled ? 'true' : 'false'}
-          aria-describedby={compareDisabled ? 'packages-compare-help' : undefined}
-          className="rounded bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-white hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Compare ({selectedPackages.length})
-        </button>
-        {compareDisabled ? (
-          <p id="packages-compare-help" className="text-xs text-[var(--textMuted)]">
-            Select at least 2 packages to compare
-          </p>
-        ) : null}
-        {compareMessage ? (
-          <div
-            role="alert"
-            data-testid="compare-message"
-            className="rounded border border-[var(--color-warning)]/30 bg-[var(--color-warning)]/10 px-3 py-2 text-xs text-[var(--color-warning)]"
-          >
-            {compareMessage}
+          {seasonOptions.length > 0 && (
+            <div className={styles.field}>
+              <label htmlFor="packages-filter-season" className={styles.fieldLabel}>
+                Season
+              </label>
+              <select
+                id="packages-filter-season"
+                data-testid="packages-filter-season"
+                className={styles.select}
+                value={seasonLabel}
+                onChange={(e) => startTransition(() => setSeasonLabel(e.target.value))}
+              >
+                <option value="all">All seasons</option>
+                {seasonOptions.map((label) => (
+                  <option key={label} value={label}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className={styles.field}>
+            <label htmlFor="packages-filter-sort" className={styles.fieldLabel}>
+              Sort
+            </label>
+            <select
+              id="packages-filter-sort"
+              data-testid="packages-filter-price"
+              className={styles.select}
+              value={sortBy}
+              onChange={(e) => startTransition(() => setSortBy(e.target.value as SortOption))}
+            >
+              <option value="relevance">Relevance</option>
+              <option value="price-asc">Price: low to high</option>
+              <option value="price-desc">Price: high to low</option>
+            </select>
           </div>
-        ) : null}
+
+          <button
+            type="button"
+            data-testid="shortlist-filter"
+            className={`${styles.savedChip} ${shortlistOnly ? styles.savedChipActive : ''}`}
+            aria-pressed={shortlistOnly}
+            onClick={() => setShortlistOnly((v) => !v)}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill={shortlistOnly ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+            </svg>
+            <span data-testid="shortlist-count">
+              Saved ({shortlistedPackages.length})
+            </span>
+          </button>
+        </div>
+
+        <p className={styles.disclosure} data-testid="sort-disclosure">
+          {NEUTRAL_SORT_DISCLOSURE}{' '}
+          <a href="/how-we-rank" className={styles.disclosureLink}>
+            How we rank
+          </a>
+        </p>
       </div>
 
       {error ? (
-        <div role="alert" className="rounded border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 px-4 py-3">
-          <p className="text-sm text-[var(--color-error)]">{error}</p>
+        <div role="alert" className={styles.alert}>
+          {error}
         </div>
+      ) : null}
+
+      {compareMessage ? (
+        <p role="alert" data-testid="compare-message" className={styles.compareMessage}>
+          {compareMessage}
+        </p>
       ) : null}
 
       {isPending ? (
-        <div role="status" className="mt-4 text-sm text-[var(--textMuted)]">
-          Updating package results...
-        </div>
+        <p role="status" className={styles.statusRow}>
+          Updating results…
+        </p>
       ) : null}
 
       {showShortlistEmpty ? (
-        <div
-          data-testid="shortlist-empty"
-          className="mt-6 rounded border border-dashed border-[var(--border)] px-4 py-6 text-center"
-        >
-          <p className="text-sm text-[var(--textMuted)]">
-            No packages in your shortlist yet. Add some to see them here.
+        <div data-testid="shortlist-empty" className={styles.empty} role="status">
+          <p className={styles.emptyTitle}>Nothing saved yet</p>
+          <p className={styles.emptyText}>
+            Tap <strong>Save</strong> on any package to keep it here for later.
           </p>
+          <button type="button" className={styles.emptyAction} onClick={() => setShortlistOnly(false)}>
+            Show all packages
+          </button>
         </div>
       ) : null}
 
-      {showEmpty && !showShortlistEmpty ? (
-        <div
-          data-testid="packages-empty"
-          className="mt-6 rounded border border-dashed border-[var(--border)] px-4 py-6 text-center"
-        >
-          <p className="text-sm text-[var(--textMuted)]">
-            No packages match these filters yet. Try clearing a filter or check back soon.
+      {showEmpty ? (
+        <div data-testid="packages-empty" className={styles.empty} role="status">
+          <p className={styles.emptyTitle}>No packages match these filters</p>
+          <p className={styles.emptyText}>
+            Try a different pilgrimage type or season — or clear your filters to see everything.
           </p>
+          <button type="button" className={styles.emptyAction} onClick={resetFilters}>
+            Clear filters
+          </button>
         </div>
       ) : null}
 
-      <ul className="mt-6 grid gap-4 md:grid-cols-2">
-        {filteredPackages.map((pkg) => (
-          <li
-            key={pkg.id}
-            data-testid={`package-card-${pkg.id}`}
-            className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-5"
-          >
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p className="text-xs uppercase tracking-wide text-[var(--textMuted)]">
-                  {pkg.pilgrimageType} · {formatSeasonLabel(pkg)}
-                </p>
-                <h2 className="mt-1 text-lg font-semibold text-[var(--text)]">
-                  <Link
-                    href={`/packages/${pkg.slug}`}
-                    data-testid={`package-link-${pkg.slug}`}
-                    className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]"
-                  >
-                    {pkg.title}
-                  </Link>
-                </h2>
-              </div>
-              <p className="text-lg font-semibold text-[var(--text)]">{formatPrice(pkg)}</p>
-            </div>
-
-            <dl className="mt-4 grid grid-cols-2 gap-2 text-sm text-[var(--textMuted)]">
-              <div>
-                <dt className="font-medium text-[var(--text)]">Total nights</dt>
-                <dd>{pkg.totalNights}</dd>
-              </div>
-              <div>
-                <dt className="font-medium text-[var(--text)]">Nights split</dt>
-                <dd>
-                  {pkg.nightsMakkah} Makkah · {pkg.nightsMadinah} Madinah
-                </dd>
-              </div>
-            </dl>
-
-            <div className="mt-4 flex items-center gap-4 text-sm text-[var(--textMuted)]">
-              <input
-                id={`package-compare-${pkg.id}`}
-                type="checkbox"
-                data-testid={`package-compare-checkbox-${pkg.id}`}
-                checked={selectedPackages.includes(pkg.id)}
-                onChange={() => {
-                  try {
-                    const next = handleComparisonSelection(selectedPackages, pkg.id)
-                    setSelectedPackages(next)
-                    setCompareMessage('')
-                  } catch (err) {
-                    setCompareMessage((err as Error).message)
-                  }
-                }}
-                className="h-4 w-4 rounded border-[var(--border)] bg-[var(--panel)] text-[var(--primary)] focus:ring-[var(--primary)]"
+      {filteredPackages.length > 0 && (
+        <ul className={styles.grid} aria-label="Packages">
+          {filteredPackages.map((pkg) => (
+            <li key={pkg.id}>
+              <PackageCard
+                package={toSearchDisplay(pkg)}
+                operator={operatorsById[pkg.operatorId]}
+                inclusions={buildInclusions(pkg)}
+                isShortlisted={shortlistedPackages.includes(pkg.id)}
+                isCompareSelected={selectedCompareIds.includes(pkg.id)}
+                compareFull={compareFull}
+                onAddToShortlist={onToggleShortlist}
+                onToggleCompare={onToggleCompare}
+                nightsMakkah={pkg.nightsMakkah}
+                nightsMadinah={pkg.nightsMadinah}
+                priceType={pkg.priceType === 'from' ? 'from' : 'exact'}
               />
-              <label htmlFor={`package-compare-${pkg.id}`} className="cursor-pointer">
-                Compare
-              </label>
-              <button
-                type="button"
-                data-testid={`shortlist-toggle-${pkg.id}`}
-                onClick={() => {
-                  setShortlistedPackages((prev) => {
-                    const next = prev.includes(pkg.id)
-                      ? prev.filter((id) => id !== pkg.id)
-                      : [...prev, pkg.id]
-                    return uniqueIds(next)
-                  })
-                }}
-                aria-pressed={shortlistedPackages.includes(pkg.id)}
-                className="rounded border border-[var(--border)] px-2 py-1 text-xs font-medium text-[var(--text)] hover:border-[var(--primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]"
-              >
-                {shortlistedPackages.includes(pkg.id) ? 'Shortlisted' : 'Shortlist'}
-              </button>
-            </div>
-          </li>
-        ))}
-      </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <CompareBar
+        items={compareItems}
+        min={COMPARE_MIN}
+        max={COMPARE_MAX}
+        onRemove={onToggleCompare}
+        onClear={() => { setSelectedCompareIds([]); setCompareMessage('') }}
+        onCompare={openComparison}
+      />
 
       <Dialog open={showComparison} onOpenChange={setShowComparison}>
-        <OverlayContent className="max-w-4xl overflow-x-auto">
+        <OverlayContent className="max-h-[min(92dvh,56rem)] w-[min(calc(100vw-1rem),68rem)] sm:w-[min(calc(100vw-2rem),68rem)]">
           <OverlayHeader>
-            <OverlayTitle>Compare Packages</OverlayTitle>
+            <OverlayTitle>Compare packages</OverlayTitle>
+            <OverlayDescription>
+              Review your selected packages side by side across price, operator, hotels, and
+              inclusions.
+            </OverlayDescription>
           </OverlayHeader>
-          <div className="mt-4">
+          <OverlayBody className="p-0">
             <ComparisonTable rows={comparisonRows} />
-          </div>
+          </OverlayBody>
         </OverlayContent>
       </Dialog>
     </section>

--- a/components/packages/packagesBrowse.module.css
+++ b/components/packages/packagesBrowse.module.css
@@ -1,0 +1,317 @@
+/* Browse Packages — toolbar + layout. Cards are styled by PackageCard's own
+   module, so this file only owns the page shell, filter toolbar, and grid.
+   Token-only colours so light/dark themes both work. */
+
+.page {
+  width: 100%;
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 1.75rem 1rem 2.5rem;
+  min-width: 0;
+}
+
+/* ─── Header ──────────────────────────────────────────────────────────── */
+.header {
+  margin-bottom: 1.25rem;
+}
+
+.title {
+  font-size: 1.75rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  margin: 0;
+  line-height: 1.15;
+}
+
+.subtitle {
+  margin: 0.375rem 0 0;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--textMuted);
+  max-width: 46ch;
+}
+
+/* ─── Toolbar ─────────────────────────────────────────────────────────── */
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding-bottom: 1rem;
+  margin-bottom: 1.25rem;
+  border-bottom: 1px solid var(--borderSubtle);
+}
+
+/* Pilgrimage-type segmented control — the primary filter, given the most weight */
+.segment {
+  display: inline-flex;
+  align-self: flex-start;
+  max-width: 100%;
+  padding: 0.25rem;
+  gap: 0.25rem;
+  background: var(--surfaceDark);
+  border: 1px solid var(--borderSubtle);
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.segmentBtn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--textMuted);
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  min-height: 40px;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.segmentBtn:hover {
+  color: var(--text);
+}
+
+.segmentBtn:focus-visible {
+  outline: 2px solid var(--focusRing);
+  outline-offset: 2px;
+}
+
+.segmentBtnActive {
+  background: var(--primary);
+  color: var(--color-text-on-brand, #fff);
+}
+
+.segmentBtnActive:hover {
+  color: var(--color-text-on-brand, #fff);
+}
+
+/* Secondary controls row: count + selects + saved */
+.controls {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+}
+
+.count {
+  display: flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  margin-right: auto;
+}
+
+.countNumber {
+  font-size: 1.625rem;
+  font-weight: 800;
+  color: var(--yellow);
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.countLabel {
+  font-size: 0.9375rem;
+  color: var(--textMuted);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3125rem;
+  min-width: 0;
+}
+
+.fieldLabel {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--textMuted);
+}
+
+.select {
+  appearance: none;
+  background: var(--surfaceDark);
+  border: 1px solid var(--borderSubtle);
+  color: var(--text);
+  font-size: 0.875rem;
+  font-weight: 500;
+  font-family: inherit;
+  padding: 0 2rem 0 0.75rem;
+  min-height: 40px;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+  /* Token-driven chevron so it themes correctly */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.625rem center;
+}
+
+.select:hover {
+  border-color: var(--borderStrong, var(--primary));
+}
+
+.select:focus-visible {
+  outline: 2px solid var(--focusRing);
+  outline-offset: 2px;
+  border-color: var(--primary);
+}
+
+.select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Saved toggle chip */
+.savedChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-height: 40px;
+  padding: 0 0.875rem;
+  background: var(--surfaceDark);
+  border: 1px solid var(--borderSubtle);
+  border-radius: 999px;
+  color: var(--textMuted);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.savedChip:hover {
+  color: var(--text);
+  border-color: var(--borderStrong, var(--primary));
+}
+
+.savedChip:focus-visible {
+  outline: 2px solid var(--focusRing);
+  outline-offset: 2px;
+}
+
+.savedChipActive {
+  color: var(--primary);
+  border-color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+}
+
+.disclosure {
+  font-size: 0.8125rem;
+  color: var(--textMuted);
+  margin: 0;
+}
+
+.disclosureLink {
+  color: var(--textMuted);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.disclosureLink:hover {
+  color: var(--text);
+}
+
+/* ─── Results grid ────────────────────────────────────────────────────── */
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.gridWithBar {
+  padding-bottom: 6rem;
+}
+
+/* ─── States ──────────────────────────────────────────────────────────── */
+.statusRow {
+  font-size: 0.875rem;
+  color: var(--textMuted);
+  margin: 0 0 1rem;
+}
+
+.alert {
+  border: 1px solid color-mix(in srgb, var(--color-error) 30%, transparent);
+  background: color-mix(in srgb, var(--color-error) 10%, transparent);
+  color: var(--color-error);
+  padding: 0.75rem 1rem;
+  border-radius: 0.625rem;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.compareMessage {
+  border: 1px solid color-mix(in srgb, var(--color-warning) 35%, transparent);
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  color: var(--color-warning);
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.5rem;
+  font-size: 0.8125rem;
+  margin-bottom: 1rem;
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.5rem;
+  padding: 3rem 1.5rem;
+  border: 1px dashed var(--borderSubtle);
+  border-radius: 1rem;
+  background: color-mix(in srgb, var(--text) 2%, transparent);
+}
+
+.emptyTitle {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0;
+}
+
+.emptyText {
+  font-size: 0.9375rem;
+  color: var(--textMuted);
+  margin: 0;
+  max-width: 38ch;
+  line-height: 1.5;
+}
+
+.emptyAction {
+  margin-top: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0.5rem 1.25rem;
+  border: 1.5px solid var(--primary);
+  border-radius: 0.625rem;
+  background: transparent;
+  color: var(--primary);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.emptyAction:hover {
+  background: var(--primary);
+  color: var(--color-text-on-brand, #fff);
+}
+
+/* ─── Two-up grid on wider screens ────────────────────────────────────── */
+@media (min-width: 760px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.25rem;
+  }
+}
+
+@media (max-width: 380px) {
+  .page {
+    padding: 1.5rem 0.75rem 2.5rem;
+  }
+}

--- a/components/search/CompareBar.module.css
+++ b/components/search/CompareBar.module.css
@@ -41,7 +41,10 @@
   flex-direction: column;
   gap: 0.125rem;
   min-width: 0;
-  flex: 1 1 auto;
+  /* Mobile: own row on top. The compare action gets its own stable row below,
+     so the button never moves as chips are added/removed. */
+  order: 1;
+  flex: 1 1 100%;
 }
 
 .count {
@@ -59,10 +62,22 @@
 .chips {
   display: flex;
   gap: 0.375rem;
-  flex-wrap: wrap;
+  /* One compact scrolling lane (mobile + desktop) so adding chips never grows
+     the bar's height and never shifts the Compare action. */
+  flex-wrap: nowrap;
+  overflow-x: auto;
   min-width: 0;
-  order: 3;
+  order: 2;
   width: 100%;
+  scrollbar-width: none;
+}
+
+.chips::-webkit-scrollbar {
+  display: none;
+}
+
+.chip {
+  flex-shrink: 0;
 }
 
 .chip {
@@ -114,6 +129,19 @@
   align-items: center;
   gap: 0.5rem;
   flex-shrink: 0;
+  /* Mobile: full-width row at the bottom — fixed home for the primary action. */
+  order: 3;
+  width: 100%;
+}
+
+/* Mobile: Compare fills the row and stays put; Clear stays compact beside it. */
+.compare {
+  flex: 1 1 auto;
+  justify-content: center;
+}
+
+.clear {
+  flex: 0 0 auto;
 }
 
 .clear {
@@ -183,15 +211,36 @@
   background: color-mix(in srgb, var(--text) 12%, transparent);
 }
 
-/* On wider screens the chips sit inline between info and actions. */
+/* Wider screens: one stable row that never wraps — info | chips lane | actions.
+   The chips lane absorbs all the flex and scrolls if needed, so the Compare
+   button stays pinned to the right regardless of how many are selected. */
 @media (min-width: 720px) {
-  .chips {
-    order: 0;
-    width: auto;
-    flex: 1 1 auto;
-    justify-content: flex-end;
+  .bar {
+    flex-wrap: nowrap;
   }
   .info {
+    order: 1;
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .chips {
+    order: 2;
+    width: auto;
+    flex: 1 1 auto;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    justify-content: flex-start;
+    /* Keep the lane quiet — no visible scrollbar chrome for 2–3 chips. */
+    scrollbar-width: none;
+  }
+  .chips::-webkit-scrollbar {
+    display: none;
+  }
+  .actions {
+    order: 3;
+    width: auto;
+  }
+  .compare {
     flex: 0 0 auto;
   }
   .chipLabel {

--- a/components/search/packages.module.css
+++ b/components/search/packages.module.css
@@ -728,6 +728,18 @@
   font-weight: 600;
 }
 
+/* On mobile the result count is long, so the Filter/Sort controls wrap onto
+   their own left-aligned row. A right-anchored menu then extends off the LEFT
+   edge of the screen (the reported crop). Anchor it to the button's left edge
+   instead and clamp to the viewport so every option stays fully visible. */
+@media (max-width: 768px) {
+  .sortDropdown {
+    left: 0;
+    right: auto;
+    max-width: calc(100vw - 1.5rem);
+  }
+}
+
 /* ─── Empty state ──────────────────────────────────────────────────────── */
 .emptyState {
   display: flex;

--- a/e2e/catalogue.spec.ts
+++ b/e2e/catalogue.spec.ts
@@ -5,13 +5,14 @@ test('Public catalogue flow: browse, detail, operator, compare', async ({ page }
   await expect(page.locator('[data-testid="packages-page"]')).toBeVisible();
   const packageCards = page.locator('[data-testid^="package-card-"]');
   await expect(packageCards.first()).toBeVisible();
-  const compareButton = page.locator('[data-testid="packages-compare-button"]');
-  await expect(compareButton).toBeVisible();
-  await expect(compareButton).toBeDisabled();
-  const compareCheckboxes = page.locator('[data-testid^="package-compare-checkbox-"]');
+  // The sticky compare bar (and its Compare button) only appears once at least
+  // one package is selected — the compare-first flow shared with /search.
+  const compareCheckboxes = page.locator('[data-testid^="package-compare-toggle-"]');
+  const compareButton = page.locator('[data-testid="search-compare-button"]');
   const packageCount = await packageCards.count();
   if (packageCount >= 1) {
     await compareCheckboxes.nth(0).check();
+    await expect(compareButton).toBeVisible();
     await expect(compareButton).toBeDisabled();
   }
   if (packageCount >= 2) {
@@ -24,7 +25,7 @@ test('Public catalogue flow: browse, detail, operator, compare', async ({ page }
     await page.keyboard.press('Escape');
   }
 
-  const firstPackageLink = page.locator('[data-testid^="package-link-"]').first();
+  const firstPackageLink = page.locator('[data-testid^="package-view-"]').first();
   await Promise.all([
     page.waitForURL('**/packages/**'),
     firstPackageLink.click(),


### PR DESCRIPTION
## Production release — UX + correctness polish

Promotes the work merged in #81. All changes are on the public traveller surface; browser-verified across light/dark themes at mobile (375px) and desktop.

- `/packages` redesign — reuses the polished `PackageCard` + sticky `CompareBar` + comparison dialog from `/search` (one consistent card language).
- CSP nonce on the inline theme script (fixes `script-src` inline-execution block).
- Light-theme kaaba background restored as a faint, readability-safe ghost.
- Homepage FAQ→CTA gap tightened (~20px).
- Mobile sort dropdown no longer crops on `/search`.
- Compare bar's primary Compare button stays put as chips change (1/2/3, both breakpoints).
- Header IA: no separate Home link (logo already links home).

### Gates (verified on the integrated dev state)
- `npm run test`: 1,833 pass · `npx tsc --noEmit`: clean · `npm run build`: 0 errors
- CI green on #81 before merge to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
