### PR TITLE
test(e2e): fix cookie-banner click-intercept flake in catalogue/operator/bank-payment

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1,7 +1,7 @@
 # PilgrimCompare AI Handover — Single Source of Truth
 
-**Last verified:** 2026-06-12 (Prompt 5 + 6 — transactional email + cron suite — 1,818 tests, 0 build errors)
-**Branch:** `dev` (clean — Q1–Q6 all merged via PRs)
+**Last verified:** 2026-06-15 (cookie-banner E2E flake fix — Vitest 1,836/1,836, E2E 45/45 ×3 serial, 0 build errors)
+**Branch:** `feature/fix-cookie-banner-e2e-flake`
 **Audience:** Claude, Codex, Kimi, and any AI/developer taking over the project.
 
 **Next immediate action:**
@@ -45,10 +45,27 @@ Server-side only — evaluated on the server and passed down as boolean props (s
 - `app/requests/page.tsx` (the customer's request list) still has `/quote` "New Request" links. It is behind customer auth (not the public pilgrim walk) and any click hits the `/quote` 404 guard. Left intact, flagged here as a minor follow-up if a cleaner empty-state is wanted.
 
 ### Outstanding (separate task, NOT a blocker for Task 1)
-- **Cookie-banner E2E flake.** 5 Playwright specs (`catalogue`, `operator`, `bank-payment`) intermittently fail because the cookie-consent banner (`data-testid="cookie-consent-banner"`, fixed bottom, z-40) intercepts pointer events on bottom-of-viewport controls (e.g. the sticky compare button). **Pre-existing** — reproduces on the `dev` baseline with this branch's code absent; which spec/browser fails varies per run. In the compare/operator pages, out of Task 1's scope. Fix later: dismiss/clear the banner in test setup (or raise the compare bar above it). Tracked as its own task.
+- ✅ **Cookie-banner E2E flake — FIXED 2026-06-15** (branch `feature/fix-cookie-banner-e2e-flake`). See §Cookie-banner E2E flake fix below.
 
 ### Next task
 **Task 2 — Build the simplified enquiry journey** (direction file §9): package-page "Enquire" → short pre-filled form (name, contact, optional travel month, optional message) → reference code + confirmation with payment-posture copy. One package, one enquiry, one operator. Branch from the updated `dev` (`05c0788`).
+
+---
+
+## §Cookie-banner E2E flake fix — 2026-06-15 (branch `feature/fix-cookie-banner-e2e-flake`)
+
+**Problem.** `e2e/catalogue.spec.ts`, `e2e/operator.spec.ts`, `e2e/bank-payment.spec.ts` intermittently failed with `<...> from <div ... data-testid="cookie-consent-banner" ...> subtree intercepts pointer events` when clicking bottom-of-viewport controls (sticky compare button, wizard/bank CTAs). The `CookieConsent` banner (`components/compliance/CookieConsent.tsx`) is `position:fixed; bottom:0; z-40`; it mounts whenever `localStorage['kb_cookie_consent_v1']` is absent and overlaps those controls. Pre-existing; which spec/browser failed varied per run.
+
+**Fix (test-setup only — no product UX touched).** New helper `e2e/helpers/cookies.ts` → `dismissCookieBanner(page)` seeds the consent key via `page.addInitScript`. Init script re-runs before page scripts on **every** navigation, so the banner never mounts — and it survives the `localStorage.clear()` calls inside `bank-payment.spec.ts` (a one-shot `page.evaluate` would not). `STORAGE_KEY` + payload shape mirror the component; keep in sync if its consent contract changes.
+
+Wired before the first navigation in:
+- `catalogue.spec.ts` — first line of the test.
+- `operator.spec.ts` — all 3 `beforeEach` hooks.
+- `bank-payment.spec.ts` — the `beforeEach`.
+
+Banner component, feature flags, and RFQ/booking flows left untouched.
+
+**Verification.** Vitest 1,836/1,836; `tsc` clean; `npm run build` 0 errors (via Playwright `webServer`). E2E run **3× under CI conditions (`--workers=1`)**: 45/45 pass each (15 tests × chromium+firefox+webkit). Zero pointer-intercept errors. (Note: locally `fullyParallel:true` with default multi-workers causes a *separate, unrelated* shared-MockDB race between `operator`/`bank-payment` specs — CI runs `workers:1` so it does not occur there; out of scope here.)
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 > **Single rolling tracker.** Any AI/dev: read this for current state. Update it after work is **done + tested + verified** (see `CLAUDE.md` rule).
 > Detailed handover lives in `AI_NOTES.md`. Cold-start brief: `HANDOFF.md`. Business: `BUSINESS.md`.
 
-**Last verified:** 2026-06-15 (Task 1 — park RFQ quote engine + booking/payment flow behind feature flags) · **Branch:** `feature/park-rfq-booking-flows` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
+**Last verified:** 2026-06-15 (cookie-banner E2E flake fix) · **Branch:** `feature/fix-cookie-banner-e2e-flake` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
 
 > **Direction:** `PILGRIMCOMPARE_PROJECT_DIRECTION.md` (repo root) is now the source of truth — read first every session. Parked features tracked in `PARKED_FEATURES.md`.
 
@@ -16,7 +16,7 @@
 | `npm run test` | ✅ 1,836/1,836 pass (29 files) |
 | `npm run build` | ✅ 0 errors |
 | `npx tsc --noEmit` | ✅ pass |
-| E2E | ⚠️ pre-existing cookie-banner click-intercept flake in `catalogue`/`operator`/`bank-payment` (reproduces on `dev` baseline; varies by run). Parked-flow paths pass. |
+| E2E | ✅ cookie-banner click-intercept flake fixed 2026-06-15 (`feature/fix-cookie-banner-e2e-flake`, AI_NOTES §Cookie-banner E2E flake fix). `catalogue`/`operator`/`bank-payment` 45/45 × 3 serial runs (chromium+firefox+webkit). |
 | Production deploy | ✅ main — Vercel live 2026-06-13 (light theme + search + pagination) |
 | Light theme | ✅ merged to dev + main 2026-06-13 |
 

--- a/e2e/bank-payment.spec.ts
+++ b/e2e/bank-payment.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { setTestUser, resetMockDB } from './helpers/auth';
+import { dismissCookieBanner } from './helpers/cookies';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -8,6 +9,7 @@ test.describe('Bank onboarding and payment flows', () => {
     // operatorAdmin: id=op1 (has seeded payment details) + role=admin (accesses /admin/bank-changes)
     // Admin role passes both /operator/* and /admin/* route guards per middleware ROLE_PROTECTED map
     await setTestUser(page, 'operatorAdmin');
+    await dismissCookieBanner(page);
   });
 
   test('operator creates change, admin approves, operator sees cooling', async ({ page }) => {

--- a/e2e/catalogue.spec.ts
+++ b/e2e/catalogue.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { dismissCookieBanner } from './helpers/cookies';
 
 test('Public catalogue flow: browse, detail, operator, compare', async ({ page }) => {
+  await dismissCookieBanner(page);
   await page.goto('/packages');
   await expect(page.locator('[data-testid="packages-page"]')).toBeVisible();
   const packageCards = page.locator('[data-testid^="package-card-"]');

--- a/e2e/helpers/cookies.ts
+++ b/e2e/helpers/cookies.ts
@@ -1,0 +1,42 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Cookie-consent banner suppression for E2E.
+ *
+ * The CookieConsent component (components/compliance/CookieConsent.tsx) renders
+ * a `position: fixed; bottom: 0; z-40` banner whenever the consent key is absent
+ * from localStorage. That banner overlaps the sticky compare bar and bottom-of-
+ * viewport CTAs, intermittently intercepting pointer events during clicks
+ * ("...subtree intercepts pointer events"). See AI_NOTES.md §Task 1 Outstanding.
+ *
+ * STORAGE_KEY and shape mirror CookieConsent.tsx exactly — keep in sync if that
+ * component's consent contract changes.
+ *
+ * Uses addInitScript (not a one-off page.evaluate) so the key is re-seeded before
+ * page scripts run on EVERY navigation. This survives the `localStorage.clear()`
+ * calls in bank-payment.spec.ts, which a one-shot seed would not.
+ *
+ * Call once per test/beforeEach before the first navigation.
+ */
+const STORAGE_KEY = 'kb_cookie_consent_v1';
+
+export async function dismissCookieBanner(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([key]) => {
+      try {
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({
+            essential: true,
+            analytics: false,
+            timestamp: '2026-01-01T00:00:00.000Z',
+          }),
+        );
+      } catch {
+        // localStorage may be unavailable in some contexts — banner stays,
+        // but the test simply behaves as it did before this helper existed.
+      }
+    },
+    [STORAGE_KEY] as const,
+  );
+}

--- a/e2e/operator.spec.ts
+++ b/e2e/operator.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { setTestUser } from './helpers/auth';
+import { dismissCookieBanner } from './helpers/cookies';
 
 /**
  * E2E tests for the operator package management flow:
@@ -25,6 +26,7 @@ import { setTestUser } from './helpers/auth';
 test.describe('Operator packages page', () => {
   test.beforeEach(async ({ page }) => {
     await setTestUser(page, 'operator');
+    await dismissCookieBanner(page);
   });
 
   test('loads packages page', async ({ page }) => {
@@ -51,6 +53,7 @@ test.describe('Operator packages page', () => {
 test.describe('PackageWizard — step navigation', () => {
   test.beforeEach(async ({ page }) => {
     await setTestUser(page, 'operator');
+    await dismissCookieBanner(page);
     await page.goto('/operator/packages');
     await page.waitForLoadState('domcontentloaded');
     await page.getByRole('button', { name: /create package/i }).first().click();
@@ -117,6 +120,7 @@ test.describe('PackageWizard — step navigation', () => {
 test.describe('PackageWizard — full flow to review', () => {
   test.beforeEach(async ({ page }) => {
     await setTestUser(page, 'operator');
+    await dismissCookieBanner(page);
   });
 
   test('walks through all 8 steps to review screen', async ({ page }) => {


### PR DESCRIPTION
## What

Fixes the pre-existing flaky-E2E issue where `e2e/catalogue.spec.ts`, `e2e/operator.spec.ts`, and `e2e/bank-payment.spec.ts` intermittently failed with:

> `<...> from <div ... data-testid="cookie-consent-banner" ...> subtree intercepts pointer events`

## Root cause

`components/compliance/CookieConsent.tsx` renders a `position:fixed; bottom:0; z-40` banner whenever `localStorage['kb_cookie_consent_v1']` is absent. It overlaps bottom-of-viewport controls (sticky compare bar, wizard/bank CTAs) and intermittently steals the click. Which spec/browser failed varied per run; reproduces on the `dev` baseline.

## Fix (test-setup only — no product UX touched)

- New helper `e2e/helpers/cookies.ts` -> `dismissCookieBanner(page)` seeds the consent key via `page.addInitScript`, so the banner never mounts.
- `addInitScript` re-runs before page scripts on **every** navigation — so it survives the `localStorage.clear()` calls inside `bank-payment.spec.ts` (a one-shot `page.evaluate` would not).
- Wired before the first navigation in `catalogue.spec.ts`, all 3 `beforeEach` hooks of `operator.spec.ts`, and the `beforeEach` of `bank-payment.spec.ts`.

The banner component, feature flags, and RFQ/booking flows are untouched.

## Verification

- `npm run test` — Vitest **1,836/1,836** pass
- `npx tsc --noEmit` — clean
- `npm run build` — 0 errors (via Playwright `webServer`)
- `npx playwright test catalogue operator bank-payment --workers=1` (CI conditions) — **45/45 pass x 3 consecutive runs** across chromium + firefox + webkit, zero pointer-intercept errors

> Note: locally, `fullyParallel:true` with default multi-workers causes a *separate, unrelated* shared-MockDB race between the `operator`/`bank-payment` specs. CI runs `workers:1` (serial), where it does not occur — out of scope for this PR.

Docs: `AI_NOTES.md` §Cookie-banner E2E flake fix + `STATUS.md` Health row updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)