### PR TITLE
feat(enquiry): canonical pilgrim enquiry journey (Task 2)

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1,16 +1,51 @@
 # PilgrimCompare AI Handover — Single Source of Truth
 
-**Last verified:** 2026-06-15 (cookie-banner E2E flake fix — Vitest 1,836/1,836, E2E 45/45 ×3 serial, 0 build errors)
-**Branch:** `feature/fix-cookie-banner-e2e-flake`
+**Last verified:** 2026-06-15 (Task 2 — pilgrim enquiry journey — Vitest 1,852/1,852, `tsc` clean, 0 build errors, enquiry E2E 3/3 ×3 browsers serial)
+**Branch:** `feature/clean-enquiry-journey`
 **Audience:** Claude, Codex, Kimi, and any AI/developer taking over the project.
 
 **Next immediate action:**
-Gate 3 — operator onboarding. Run the 3 DB migration SQL statements in §23 against Supabase before deploying. Then begin operator acquisition.
-See §10 + §23 for queue context.
+Task 3 — compliant pilgrim email opt-in (direction file §9). Add a separate, unticked marketing opt-in to the enquiry form with a stored consent record (timestamp, source, exact wording) + unsubscribe/suppression. Structural room already left in `lib/validation.ts` (`enquirySchema`), `lib/types.ts` (`Enquiry`), `components/enquiry/EnquiryForm.tsx`, and migration `010`.
 
 This file is the current handover source of truth. If another document conflicts with a verified statement here, treat that other document as stale and update it before changing implementation.
 
 > **Precedence note (2026-06-15):** `PILGRIMCOMPARE_PROJECT_DIRECTION.md` (repo root) is now the single source of truth for product direction and **must be read first every session**, before this file. It wins all conflicts except the language/legal red lines. `PARKED_FEATURES.md` (repo root) is the canonical parked-feature register.
+
+---
+
+## §Task 2 — Canonical pilgrim enquiry journey — 2026-06-15
+
+**Status: ✅ COMPLETE on branch `feature/clean-enquiry-journey`** (off `dev` `05c0788`). One package, one enquiry, one operator. **Anonymous** — no login required. Vitest **1,852/1,852** (+16), `tsc` clean, `npm run build` 0 errors, enquiry E2E 3/3 ×3 browsers (serial).
+
+### What was built
+- **Entry point:** package page (`components/packages/PackageDetail.tsx`) now has an always-live **Enquire** CTA (desktop rail `package-cta-enquire` + mobile sticky `package-mobile-cta-enquire`) → `/packages/[slug]/enquire`. Before this, the only CTA was the parked "Request quote" (hidden with flag off) — so there was *no* live way to enquire.
+- **Form** (`app/packages/[slug]/enquire/page.tsx` server → `components/enquiry/EnquiryForm.tsx` client): read-only package+operator summary (trip type, departure airport, duration, hotels, price — "Not provided" when absent), then fields **and only these**: Name (required), Email and/or Phone (≥1 required), Travel month (optional), Message (optional). Does **not** re-ask anything the package states.
+- **Submit:** `POST /api/enquiries` (anonymous, IP rate-limited scope `'enquiry'`). Resolves package+operator **server-side** (honest names, never client-supplied), persists an `Enquiry` with a unique reference code + timestamp, returns `{ referenceCode }`. Confirmation screen shows the reference code, a plain "what happens next" line, and the **three verbatim payment-posture lines**.
+
+### Data model / persistence (decision)
+- New **`Enquiry`** entity through the normal Repository stack (NOT the parked `QuoteRequest`, which needs a non-null `customerId` FK = auth-only; NOT the `interests` raw-SQL shortcut, which bypasses Repository and would not work under E2E/MockDB).
+- Prisma model `Enquiry` (`prisma/schema.prisma`) + raw migration **`supabase/migrations/010_enquiries_table.sql`** (`enquiries` table, RLS on, service-role only). **Migration already applied to Supabase** via `DIRECT_URL` (additive `CREATE TABLE IF NOT EXISTS`) — preview/prod persistence works now.
+- Wired through `lib/api/mock-db.ts` (get/saveEnquiry + `ENQUIRIES` key), `lib/api/db/adapter.ts` (`mapEnquiry`/`getEnquiries`/`saveEnquiry`), `lib/api/repository.ts` (`createEnquiry`, mockStore wrapper).
+
+### Reference code (reused, not duplicated)
+`Repository.createEnquiry` reuses the existing in-module `generateReferenceCode(existingCodes)` (`KT-XXXXXXXX`, unique, 10-attempt) — same generator BookingIntent uses. Single source; no new scattered logic. Codes are `KT-` (consistent with the existing prefix).
+
+### Emails — DO they send via Resend?
+**Yes, wired and sendable.** Uses the **existing** Resend setup only (`lib/email/send.tsx`): `sendEnquiryConfirmation` (pilgrim) + `sendOperatorEnquiryAlert` (operator). Fire-and-forget — both are try/catch and **never fail the enquiry**; the record persists and the confirmation screen shows regardless. Confirmation email sent only when the pilgrim gave an email; operator alert only when the operator has a `contactEmail`. No new email infra scaffolded (per task constraint). Prod has `RESEND_API_KEY`; in E2E/local without it, `resendClient()` throws and is swallowed — persistence + confirmation still succeed.
+
+### Posture copy (single source)
+`lib/content-rules.ts` now exports `CONTRACT_STANDARD_LINE`, `REFERENCE_CODE_STANDARD_LINE`, and `PAYMENT_POSTURE_LINES` (the three verbatim lines, in order). Confirmation renders them from this constant — do not paraphrase. (`lib/legal.ts` holds only the entity block, not these strings.)
+
+### Files changed
+`prisma/schema.prisma`, `supabase/migrations/010_enquiries_table.sql` (new), `lib/types.ts` (`Enquiry`), `lib/validation.ts` (`enquirySchema`), `lib/content-rules.ts` (posture lines), `lib/api/mock-db.ts`, `lib/api/db/adapter.ts`, `lib/api/repository.ts`, `app/api/enquiries/route.ts` (new), `components/enquiry/EnquiryForm.tsx` (new), `app/packages/[slug]/enquire/page.tsx` (new), `components/packages/PackageDetail.tsx` (Enquire CTAs). Tests: `tests/enquiry.test.ts`, `tests/enquiry-api.test.ts`, `e2e/enquiry.spec.ts` (all new).
+
+### Parked flows untouched
+`FEATURE_BOOKING_FLOW` / `FEATURE_RFQ_QUOTE` unchanged (default OFF). The parked RFQ "Request quote" CTA blocks in `PackageDetail.tsx` are untouched — the new Enquire CTA sits alongside them. PARKED_FEATURES.md unchanged (no flag/path changed).
+
+### Open risks / notes
+- Full E2E suite (serial): the new enquiry spec + everything passes except a **pre-existing webkit `operator.spec.ts` "loads packages page" flake** under full-suite load — passes in isolation (10/10), unrelated to this task (operator-login timing; my diff doesn't touch operator pages).
+- No analytics/lead-counting event emitted on enquiry — deliberately deferred to **Task 4** (lead logging + per-operator counting). `createEnquiry` is pure persistence.
+- Marketing opt-in is **Task 3** — structural room left, not built.
 
 ---
 

--- a/app/api/enquiries/route.ts
+++ b/app/api/enquiries/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { enquirySchema } from '@/lib/validation';
+import { Repository } from '@/lib/api/repository';
+import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit';
+import { mapErrorToResponse } from '@/lib/errors';
+import { sendEnquiryConfirmation, sendOperatorEnquiryAlert } from '@/lib/email/send';
+import type { Enquiry, OperatorProfile, Package } from '@/lib/types';
+
+/**
+ * Canonical pilgrim enquiry (Task 2): one package, one enquiry, one operator.
+ * Anonymous — no auth required. Persists the enquiry with a unique reference
+ * code, then fires confirmation + operator-alert emails via the EXISTING Resend
+ * setup (fire-and-forget; email failure never fails the enquiry).
+ */
+export async function POST(request: NextRequest) {
+  // Throttle by IP. Scoped separately from auth / quote / interest buckets.
+  const rateLimit = await checkRateLimit(getRateLimitIdentifier(request, 'enquiry'));
+  if (rateLimit.limited) {
+    return NextResponse.json(
+      { error: 'Too many attempts. Please try again later.' },
+      { status: 429, headers: { 'Retry-After': String(rateLimit.retryAfter) } }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const parsed = enquirySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+    }
+
+    const { packageId, name, email, phone, travelMonth, message } = parsed.data;
+
+    // Resolve the package + operator server-side so the lead carries honest,
+    // package-sourced names (never client-supplied). Reject unknown/unpublished.
+    const pkg = await Repository.getPackageById(packageId);
+    if (!pkg || pkg.status !== 'published') {
+      return NextResponse.json({ error: 'This package is no longer available.' }, { status: 404 });
+    }
+    const operator = await Repository.getOperatorById(pkg.operatorId);
+
+    const enquiry = await Repository.createEnquiry({
+      packageId: pkg.id,
+      operatorId: pkg.operatorId,
+      packageTitle: pkg.title,
+      operatorName: operator?.tradingName ?? operator?.companyName,
+      name,
+      email: email || undefined,
+      phone: phone || undefined,
+      travelMonth: travelMonth || undefined,
+      message: message || undefined,
+    });
+
+    // Fire-and-forget: emails must not fail the API response.
+    void sendEnquiryEmails(enquiry, pkg, operator);
+
+    return NextResponse.json({ referenceCode: enquiry.referenceCode }, { status: 201 });
+  } catch (err) {
+    const { body, status } = mapErrorToResponse(err);
+    return NextResponse.json(body, { status });
+  }
+}
+
+async function sendEnquiryEmails(
+  enquiry: Enquiry,
+  pkg: Package,
+  operator: OperatorProfile | undefined
+): Promise<void> {
+  try {
+    const operatorName = enquiry.operatorName ?? 'the operator';
+    const packageName = enquiry.packageTitle ?? pkg.title;
+
+    // Pilgrim confirmation — only when an email was provided.
+    if (enquiry.email) {
+      await sendEnquiryConfirmation({
+        customerEmail: enquiry.email,
+        customerName: enquiry.name || 'Pilgrim',
+        packageName,
+        operatorName,
+        refCode: enquiry.referenceCode,
+        similarPackages: [],
+      });
+    }
+
+    // Operator lead alert — only when the operator has a contact email.
+    if (operator?.contactEmail) {
+      await sendOperatorEnquiryAlert({
+        operatorEmail: operator.contactEmail,
+        operatorName,
+        customerName: enquiry.name || enquiry.email || enquiry.phone || 'A pilgrim',
+        customerEmail: enquiry.email ?? '',
+        customerPhone: enquiry.phone,
+        packageName,
+        travelDates: enquiry.travelMonth ?? 'Not provided',
+        groupSize: 'Not provided',
+        message: enquiry.message ?? '',
+        refCode: enquiry.referenceCode,
+      });
+    }
+  } catch (err) {
+    console.error('[email] sendEnquiryEmails failed:', err);
+  }
+}

--- a/app/packages/[slug]/enquire/page.tsx
+++ b/app/packages/[slug]/enquire/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from 'next'
+import { EnquiryForm, type EnquirySummary } from '@/components/enquiry/EnquiryForm'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
+import { Repository } from '@/lib/api/repository'
+import type { OperatorProfile, Package } from '@/lib/types'
+
+export const metadata: Metadata = {
+  title: 'Enquire | PilgrimCompare',
+  description: 'Send a short enquiry to the operator about this package.',
+  robots: { index: false, follow: false },
+}
+
+const NOT_PROVIDED = 'Not provided'
+
+const renderNotice = (message: string) => (
+  <section className="w-full max-w-2xl mx-auto px-4 py-16">
+    <div role="alert" data-testid="enquiry-package-not-found" className="rounded border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 px-5 py-4">
+      <h1 className="text-2xl font-semibold text-[var(--text)]">Package not available</h1>
+      <p className="mt-2 text-sm text-[var(--color-error)]">{message}</p>
+    </div>
+  </section>
+)
+
+/** Build the read-only summary from package data. Honest: missing → "Not provided". */
+function buildSummary(pkg: Package, operator: OperatorProfile | undefined): EnquirySummary {
+  const tripType = pkg.pilgrimageType === 'hajj' ? 'Hajj' : 'Umrah'
+  const price = `${pkg.priceType === 'from' ? 'From ' : ''}£${pkg.pricePerPerson.toLocaleString('en-GB')} per person`
+  const stars = [
+    pkg.hotelMakkahStars ? `${pkg.hotelMakkahStars}★ Makkah` : null,
+    pkg.hotelMadinahStars ? `${pkg.hotelMadinahStars}★ Madinah` : null,
+  ].filter(Boolean)
+
+  return {
+    packageId: pkg.id,
+    packageTitle: pkg.title,
+    operatorName: operator?.tradingName ?? operator?.companyName ?? 'the travel operator',
+    tripType,
+    departureAirport: pkg.departureAirport || NOT_PROVIDED,
+    duration: `${pkg.totalNights} nights (${pkg.nightsMakkah} Makkah · ${pkg.nightsMadinah} Madinah)`,
+    hotels: stars.length > 0 ? stars.join(' · ') : NOT_PROVIDED,
+    price,
+  }
+}
+
+export default async function EnquirePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+
+  let pkg: Package | undefined
+  let operator: OperatorProfile | undefined
+  try {
+    pkg = await Repository.getPackageBySlug(slug)
+    if (pkg) operator = await Repository.getOperatorById(pkg.operatorId)
+  } catch {
+    return <main className="min-h-screen bg-[var(--background)]">{renderNotice('We could not load this package right now. Please try again.')}</main>
+  }
+
+  if (!pkg || pkg.status !== 'published') {
+    return <main className="min-h-screen bg-[var(--background)]">{renderNotice('This package is no longer available.')}</main>
+  }
+
+  const breadcrumbItems = [
+    { label: 'Home', href: '/' },
+    { label: 'Packages', href: '/search/packages' },
+    { label: pkg.title, href: `/packages/${pkg.slug}` },
+    { label: 'Enquire' },
+  ]
+
+  return (
+    <main className="min-h-screen bg-[var(--background)]">
+      <div className="w-full max-w-2xl mx-auto px-4 pt-6">
+        <Breadcrumb items={breadcrumbItems} />
+      </div>
+      <EnquiryForm summary={buildSummary(pkg, operator)} packageSlug={pkg.slug} />
+    </main>
+  )
+}

--- a/components/enquiry/EnquiryForm.tsx
+++ b/components/enquiry/EnquiryForm.tsx
@@ -1,0 +1,266 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { buttonVariants } from '@/components/ui/Button'
+import { PAYMENT_POSTURE_LINES } from '@/lib/content-rules'
+
+/**
+ * Read-only summary of the package being enquired about. Pulled from the package
+ * data on the server — the form must NOT re-ask any of this (trip type, airport,
+ * duration, hotel rating, budget). Shown so the pilgrim can confirm what they are
+ * enquiring about. "Not provided" for anything the package does not state.
+ */
+export interface EnquirySummary {
+  packageId: string
+  packageTitle: string
+  operatorName: string
+  tripType: string
+  departureAirport: string
+  duration: string
+  hotels: string
+  price: string
+}
+
+interface EnquiryFormProps {
+  summary: EnquirySummary
+  packageSlug: string
+}
+
+type SubmitState = { status: 'idle' | 'submitting' } | { status: 'error'; message: string }
+
+export function EnquiryForm({ summary, packageSlug }: EnquiryFormProps) {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [phone, setPhone] = useState('')
+  const [travelMonth, setTravelMonth] = useState('')
+  const [message, setMessage] = useState('')
+  const [submit, setSubmit] = useState<SubmitState>({ status: 'idle' })
+  const [referenceCode, setReferenceCode] = useState<string | null>(null)
+
+  // Client-side mirror of the server rule: name + at least one contact.
+  const hasContact = email.trim().length > 0 || phone.trim().length > 0
+  const canSubmit = name.trim().length > 0 && hasContact && submit.status !== 'submitting'
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) {
+      setSubmit({ status: 'error', message: 'Add your name and an email or phone number so the operator can reply.' })
+      return
+    }
+    setSubmit({ status: 'submitting' })
+    try {
+      const res = await fetch('/api/enquiries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          packageId: summary.packageId,
+          name: name.trim(),
+          email: email.trim(),
+          phone: phone.trim(),
+          travelMonth: travelMonth.trim(),
+          message: message.trim(),
+        }),
+      })
+      const data = (await res.json().catch(() => ({}))) as { referenceCode?: string; error?: string }
+      if (!res.ok || !data.referenceCode) {
+        setSubmit({ status: 'error', message: data.error ?? 'Something went wrong. Please try again.' })
+        return
+      }
+      setReferenceCode(data.referenceCode)
+    } catch {
+      setSubmit({ status: 'error', message: 'Network error. Please check your connection and try again.' })
+    }
+  }
+
+  if (referenceCode) {
+    return (
+      <section data-testid="enquiry-confirmation" className="w-full max-w-2xl mx-auto px-4 py-10">
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--panel)] p-6 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-success)]/15 text-[var(--color-success)]" aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M20 6L9 17l-5-5" /></svg>
+          </div>
+          <h1 className="mt-4 text-2xl font-semibold text-[var(--text)]">Enquiry sent</h1>
+          <p className="mt-2 text-sm text-[var(--textMuted)]">
+            Your enquiry for <span className="font-medium text-[var(--text)]">{summary.packageTitle}</span> has gone to{' '}
+            <span className="font-medium text-[var(--text)]">{summary.operatorName}</span>.
+          </p>
+
+          <div className="mt-5 rounded-lg border border-[var(--border)] bg-[rgba(255,255,255,0.02)] px-4 py-4">
+            <p className="text-xs uppercase tracking-wide text-[var(--textMuted)]">Your reference code</p>
+            <p data-testid="enquiry-reference-code" className="mt-1 text-2xl font-bold tracking-wide text-[var(--yellow)]">
+              {referenceCode}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 rounded-xl border border-[var(--border)] bg-[var(--panel)] p-5">
+          <h2 className="text-base font-semibold text-[var(--text)]">What happens next</h2>
+          <p className="mt-2 text-sm leading-relaxed text-[var(--textMuted)]">
+            {summary.operatorName} will contact you directly to confirm live price and availability. Keep your reference code handy if you need to follow up.
+          </p>
+        </div>
+
+        <div data-testid="enquiry-payment-posture" className="mt-5 rounded-xl border border-[var(--border)] bg-[var(--panel)] p-5">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--textMuted)]">Before you pay</h2>
+          <ul className="mt-3 space-y-2 text-sm leading-relaxed text-[var(--textMuted)]">
+            {PAYMENT_POSTURE_LINES.map((line) => (
+              <li key={line} className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 text-[var(--yellow)]">•</span>
+                <span>{line}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link href="/search/packages" className={buttonVariants({ variant: 'primary', size: 'md' })}>
+            Compare more packages
+          </Link>
+          <Link href={`/packages/${packageSlug}`} className={buttonVariants({ variant: 'secondary', size: 'md' })}>
+            Back to this package
+          </Link>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section data-testid="enquiry-form-page" className="w-full max-w-2xl mx-auto px-4 py-8">
+      <header className="mb-5">
+        <h1 className="text-2xl font-semibold text-[var(--text)]">Enquire about this package</h1>
+        <p className="mt-1 text-sm text-[var(--textMuted)]">
+          A few details and the operator gets back to you directly. No account needed.
+        </p>
+      </header>
+
+      {/* Read-only: what you're enquiring about. The form never re-asks these. */}
+      <div data-testid="enquiry-package-summary" className="mb-6 rounded-xl border border-[var(--border)] bg-[var(--panel)] p-5">
+        <p className="text-xs uppercase tracking-wide text-[var(--textMuted)]">You&apos;re enquiring about</p>
+        <p className="mt-1 text-base font-semibold text-[var(--text)]">{summary.packageTitle}</p>
+        <p className="text-sm text-[var(--textMuted)]">Sold by {summary.operatorName}</p>
+        <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+          <SummaryFact term="Trip" value={summary.tripType} />
+          <SummaryFact term="From" value={summary.departureAirport} />
+          <SummaryFact term="Duration" value={summary.duration} />
+          <SummaryFact term="Hotels" value={summary.hotels} />
+          <SummaryFact term="Price" value={summary.price} />
+        </dl>
+      </div>
+
+      <form onSubmit={handleSubmit} noValidate className="grid gap-4">
+        <Field label="Your name" required htmlFor="enquiry-name">
+          <input
+            id="enquiry-name"
+            data-testid="enquiry-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoComplete="name"
+            required
+            className={inputClass}
+          />
+        </Field>
+
+        <fieldset className="grid gap-4 rounded-lg border border-[var(--border)] p-4">
+          <legend className="px-1 text-xs font-medium uppercase tracking-wide text-[var(--textMuted)]">
+            How should the operator reach you? (at least one)
+          </legend>
+          <Field label="Email" htmlFor="enquiry-email">
+            <input
+              id="enquiry-email"
+              data-testid="enquiry-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="email"
+              inputMode="email"
+              className={inputClass}
+            />
+          </Field>
+          <Field label="Phone" htmlFor="enquiry-phone">
+            <input
+              id="enquiry-phone"
+              data-testid="enquiry-phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              autoComplete="tel"
+              inputMode="tel"
+              className={inputClass}
+            />
+          </Field>
+        </fieldset>
+
+        <Field label="Travel month (optional)" htmlFor="enquiry-travel-month">
+          <input
+            id="enquiry-travel-month"
+            data-testid="enquiry-travel-month"
+            type="text"
+            value={travelMonth}
+            onChange={(e) => setTravelMonth(e.target.value)}
+            placeholder="e.g. March 2026"
+            className={inputClass}
+          />
+        </Field>
+
+        <Field label="Message (optional)" htmlFor="enquiry-message">
+          <textarea
+            id="enquiry-message"
+            data-testid="enquiry-message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows={4}
+            placeholder="Anything you'd like the operator to know?"
+            className={`${inputClass} resize-y`}
+          />
+        </Field>
+
+        {/* Task 3: a separate, unticked marketing opt-in goes here. */}
+
+        {submit.status === 'error' && (
+          <p data-testid="enquiry-error" role="alert" className="text-sm text-[var(--danger)]">
+            {submit.message}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          data-testid="enquiry-submit"
+          disabled={!canSubmit}
+          className={buttonVariants({ variant: 'primary', size: 'md', className: 'w-full disabled:opacity-50 disabled:cursor-not-allowed' })}
+        >
+          {submit.status === 'submitting' ? 'Sending…' : 'Send enquiry'}
+        </button>
+
+        <p className="text-center text-xs leading-relaxed text-[var(--textMuted)]">
+          {PAYMENT_POSTURE_LINES[0]}
+        </p>
+      </form>
+    </section>
+  )
+}
+
+const inputClass =
+  'w-full rounded-lg border border-[var(--border)] bg-[var(--surfaceDark)] px-3 py-2.5 text-sm text-[var(--text)] outline-none transition-colors focus:border-[var(--yellow)] focus-visible:outline-2 focus-visible:outline-[var(--yellow)] focus-visible:outline-offset-1'
+
+function Field({ label, required, htmlFor, children }: { label: string; required?: boolean; htmlFor: string; children: React.ReactNode }) {
+  return (
+    <label htmlFor={htmlFor} className="grid gap-1.5">
+      <span className="text-sm font-medium text-[var(--text)]">
+        {label}
+        {required && <span className="ml-1 text-[var(--danger)]" aria-hidden="true">*</span>}
+      </span>
+      {children}
+    </label>
+  )
+}
+
+function SummaryFact({ term, value }: { term: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-[var(--textMuted)]">{term}</dt>
+      <dd className="mt-0.5 font-medium text-[var(--text)]">{value}</dd>
+    </div>
+  )
+}

--- a/components/packages/PackageDetail.tsx
+++ b/components/packages/PackageDetail.tsx
@@ -301,6 +301,11 @@ export function PackageDetail({ pkg, operator, rfqEnabled = false }: PackageDeta
               {makkahDist && <RailFact label={makkahDist.primary} />}
               <RailFact label={hasProtection ? 'ATOL/ABTA listed' : 'No ATOL/ABTA listed'} tone={hasProtection ? 'good' : 'warn'} />
             </ul>
+            {/* Canonical enquiry entry point — always live (Task 2). */}
+            <Link href={`/packages/${pkg.slug}/enquire`} data-testid="package-cta-enquire" className={buttonVariants({ variant: 'primary', size: 'md', className: 'mt-5 w-full' })}>
+              Enquire
+            </Link>
+            <p className="mt-2 text-center text-xs text-[var(--textMuted)]">Free · the operator contacts you directly</p>
             {/* PARKED: RFQ quote engine — CTA hidden when flag off (PARKED_FEATURES.md entry 2). */}
             {rfqEnabled && (
               <>
@@ -321,6 +326,10 @@ export function PackageDetail({ pkg, operator, rfqEnabled = false }: PackageDeta
             <p className="text-xs text-[var(--textMuted)]">{pkg.priceType === 'from' ? 'From · per person' : 'Per person'}</p>
             <p className="text-lg font-bold text-[var(--text)]">{priceLabel}</p>
           </div>
+          {/* Canonical enquiry entry point — always live (Task 2). */}
+          <Link href={`/packages/${pkg.slug}/enquire`} data-testid="package-mobile-cta-enquire" className={buttonVariants({ variant: 'primary', size: 'md', className: 'px-5 whitespace-nowrap' })}>
+            Enquire
+          </Link>
           {/* PARKED: RFQ quote engine — CTA hidden when flag off (PARKED_FEATURES.md entry 2). */}
           {rfqEnabled && (
             <Link href={quoteUrl} data-testid="package-mobile-cta-request-quote" className={buttonVariants({ variant: 'primary', size: 'md', className: 'px-5 whitespace-nowrap' })}>

--- a/e2e/enquiry.spec.ts
+++ b/e2e/enquiry.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { dismissCookieBanner } from './helpers/cookies';
+
+// Task 2 — canonical pilgrim enquiry journey: browse → package → Enquire →
+// short form → confirmation with reference code + payment posture. Anonymous.
+test('Pilgrim enquiry journey: package → enquire → confirmation', async ({ page }) => {
+  await dismissCookieBanner(page);
+
+  await page.goto('/packages');
+  const firstPackageLink = page.locator('[data-testid^="package-view-"]').first();
+  await expect(firstPackageLink).toBeVisible();
+  await Promise.all([page.waitForURL('**/packages/**'), firstPackageLink.click()]);
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.locator('[data-testid="package-detail-page"]')).toBeVisible();
+
+  // Enquire entry point (always live).
+  const enquireCta = page.locator('[data-testid="package-cta-enquire"]');
+  await expect(enquireCta).toBeVisible();
+  await Promise.all([page.waitForURL('**/enquire'), enquireCta.click()]);
+  await page.waitForLoadState('domcontentloaded');
+
+  await expect(page.locator('[data-testid="enquiry-form-page"]')).toBeVisible();
+  // The form shows the package read-only and never re-asks it.
+  await expect(page.locator('[data-testid="enquiry-package-summary"]')).toBeVisible();
+
+  await page.locator('[data-testid="enquiry-name"]').fill('Aisha Khan');
+  await page.locator('[data-testid="enquiry-email"]').fill('aisha@example.com');
+  await page.locator('[data-testid="enquiry-submit"]').click();
+
+  // Confirmation: reference code + payment-posture copy.
+  await expect(page.locator('[data-testid="enquiry-confirmation"]')).toBeVisible();
+  await expect(page.locator('[data-testid="enquiry-reference-code"]')).toContainText(/KT-/);
+  await expect(page.locator('[data-testid="enquiry-payment-posture"]')).toContainText(
+    'You pay the operator directly. PilgrimCompare does not receive or hold your payment.'
+  );
+  await expect(page.locator('[data-testid="enquiry-payment-posture"]')).toContainText(
+    'a tracking code, not a payment receipt'
+  );
+});

--- a/lib/api/db/adapter.ts
+++ b/lib/api/db/adapter.ts
@@ -6,6 +6,7 @@ import type {
   BankChangeRequest,
   BookingIntent,
   Complaint,
+  Enquiry,
   Offer,
   OperatorProfile,
   Package,
@@ -24,6 +25,7 @@ import type {
   BookingIntentModel as PrismaBookingIntent,
   AnalyticsEventModel as PrismaAnalyticsEvent,
   ComplaintModel as PrismaComplaint,
+  EnquiryModel as PrismaEnquiry,
 } from '@/lib/generated/prisma/models';
 
 // ─── Helpers ─────────────────────────────────────────────────────────
@@ -142,6 +144,21 @@ const mapQuoteRequest = (qr: PrismaQuoteRequest): QuoteRequest => ({
   inclusions: qr.inclusions as QuoteRequest['inclusions'],
   notes: qr.notes ?? undefined,
   sourceOperatorId: qr.sourceOperatorId ?? undefined,
+});
+
+const mapEnquiry = (e: PrismaEnquiry): Enquiry => ({
+  id: e.id,
+  referenceCode: e.referenceCode,
+  createdAt: e.createdAt.toISOString(),
+  packageId: e.packageId,
+  operatorId: e.operatorId ?? undefined,
+  packageTitle: e.packageTitle ?? undefined,
+  operatorName: e.operatorName ?? undefined,
+  name: e.name,
+  email: e.email ?? undefined,
+  phone: e.phone ?? undefined,
+  travelMonth: e.travelMonth ?? undefined,
+  message: e.message ?? undefined,
 });
 
 const mapOffer = (o: PrismaOffer): Offer => ({
@@ -584,6 +601,32 @@ export const DBAdapter = {
       update: { ...data, updatedAt: dateOrNow(complaint.updatedAt) },
     });
     return mapComplaint(saved);
+  },
+
+  // Enquiries (canonical pilgrim enquiry — Task 2)
+  getEnquiries: async (): Promise<Enquiry[]> =>
+    (await prisma.enquiry.findMany()).map(mapEnquiry),
+
+  saveEnquiry: async (enquiry: Enquiry): Promise<Enquiry> => {
+    const data = {
+      id: enquiry.id,
+      referenceCode: enquiry.referenceCode,
+      packageId: enquiry.packageId,
+      operatorId: enquiry.operatorId ?? null,
+      packageTitle: enquiry.packageTitle ?? null,
+      operatorName: enquiry.operatorName ?? null,
+      name: enquiry.name,
+      email: enquiry.email ?? null,
+      phone: enquiry.phone ?? null,
+      travelMonth: enquiry.travelMonth ?? null,
+      message: enquiry.message ?? null,
+    };
+    const saved = await prisma.enquiry.upsert({
+      where: { id: enquiry.id },
+      create: { ...data, createdAt: dateOrNow(enquiry.createdAt) },
+      update: data,
+    });
+    return mapEnquiry(saved);
   },
 
   // Transaction support

--- a/lib/api/mock-db.ts
+++ b/lib/api/mock-db.ts
@@ -5,6 +5,7 @@ import {
   BookingIntent,
   BookingOutcome,
   Complaint,
+  Enquiry,
   Offer,
   OperatorProfile,
   Package,
@@ -28,6 +29,7 @@ const STORAGE_KEYS = {
   ANALYTICS_EVENTS: 'kb_analytics_events',
   COMPLAINTS: 'kb_complaints',
   INTERESTS: 'kb_interests',
+  ENQUIRIES: 'kb_enquiries',
 };
 
 const PACKAGES_SEED_VERSION = 5;
@@ -1142,6 +1144,20 @@ export const MockDB = {
     interests.push({ email, type, createdAt: new Date().toISOString() });
     setStorage(STORAGE_KEYS.INTERESTS, interests);
     return { email, type, createdAt: new Date().toISOString() };
+  },
+
+  getEnquiries: (): Enquiry[] => getStorage<Enquiry[]>(STORAGE_KEYS.ENQUIRIES, []),
+
+  saveEnquiry: (enquiry: Enquiry) => {
+    const enquiries = MockDB.getEnquiries();
+    const existingIndex = enquiries.findIndex((e) => e.id === enquiry.id);
+    if (existingIndex >= 0) {
+      enquiries[existingIndex] = enquiry;
+    } else {
+      enquiries.push(enquiry);
+    }
+    setStorage(STORAGE_KEYS.ENQUIRIES, enquiries);
+    return enquiry;
   },
 
   getBookingOutcomes: (): BookingOutcome[] =>

--- a/lib/api/repository.ts
+++ b/lib/api/repository.ts
@@ -19,6 +19,7 @@ import {
   ComplaintCategory,
   ComplaintSeverity,
   ComplaintStatus,
+  Enquiry,
   Offer,
   OperatorProfile,
   Package,
@@ -63,6 +64,8 @@ const mockStore = {
   saveAnalyticsEvent: (event: AnalyticsEvent) => Promise.resolve(MockDB.saveAnalyticsEvent(event)),
   saveComplaint: (c: Complaint) => Promise.resolve(MockDB.saveComplaint(c)),
   deletePackage: (id: string) => Promise.resolve(MockDB.deletePackage(id)),
+  getEnquiries: () => Promise.resolve(MockDB.getEnquiries()),
+  saveEnquiry: (enquiry: Enquiry) => Promise.resolve(MockDB.saveEnquiry(enquiry)),
   getBookingOutcomes: () => Promise.resolve(MockDB.getBookingOutcomes()),
   saveBookingOutcome: (bo: BookingOutcome) => Promise.resolve(MockDB.saveBookingOutcome(bo)),
   getDistinctDepartureCities: (): Promise<string[]> => {
@@ -523,6 +526,42 @@ export const Repository = {
     }
 
     return Array.from(rows.values());
+  },
+
+  // Enquiries (canonical pilgrim enquiry — Task 2). Anonymous: no RequestContext.
+  // Reuses the existing KT- reference-code generator (single source, no scatter).
+  createEnquiry: async (input: {
+    packageId: string;
+    operatorId?: string;
+    packageTitle?: string;
+    operatorName?: string;
+    name: string;
+    email?: string;
+    phone?: string;
+    travelMonth?: string;
+    message?: string;
+  }): Promise<Enquiry> => {
+    const existing = await store().getEnquiries();
+    const existingCodes = new Set(
+      existing.map((e) => e.referenceCode).filter((code): code is string => Boolean(code))
+    );
+
+    const enquiry: Enquiry = {
+      id: crypto.randomUUID(),
+      referenceCode: generateReferenceCode(existingCodes),
+      createdAt: new Date().toISOString(),
+      packageId: input.packageId,
+      operatorId: input.operatorId,
+      packageTitle: cleanOptionalText(input.packageTitle),
+      operatorName: cleanOptionalText(input.operatorName),
+      name: input.name.trim(),
+      email: cleanOptionalText(input.email),
+      phone: cleanOptionalText(input.phone),
+      travelMonth: cleanOptionalText(input.travelMonth),
+      message: cleanOptionalText(input.message),
+    };
+
+    return store().saveEnquiry(enquiry);
   },
 
   // Quote Requests

--- a/lib/content-rules.ts
+++ b/lib/content-rules.ts
@@ -86,6 +86,26 @@ export const PAYMENT_STANDARD_LINE =
   'You pay the operator directly. PilgrimCompare does not receive or hold your payment.'
 
 /**
+ * §4 standard copy lines 2 and 3. Verbatim — do not paraphrase.
+ * Shown with PAYMENT_STANDARD_LINE on the enquiry confirmation screen.
+ */
+export const CONTRACT_STANDARD_LINE =
+  'Your travel contract, cancellations and refunds are with the operator named on this page.'
+
+export const REFERENCE_CODE_STANDARD_LINE =
+  'Your PilgrimCompare reference code is a tracking code, not a payment receipt.'
+
+/**
+ * The three canonical payment-posture lines, in order. Single source for the
+ * enquiry confirmation screen. Verbatim — do not paraphrase or reorder.
+ */
+export const PAYMENT_POSTURE_LINES = [
+  PAYMENT_STANDARD_LINE,
+  CONTRACT_STANDARD_LINE,
+  REFERENCE_CODE_STANDARD_LINE,
+] as const
+
+/**
  * Homepage FAQ — defined once and fed to BOTH the FAQPage JSON-LD and the
  * visible on-page FAQ section, so the structured data is never orphaned.
  */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -230,6 +230,31 @@ export interface QuoteRequest {
   notes?: string;
 }
 
+/**
+ * Canonical pilgrim enquiry (Task 2): one package, one enquiry, one operator.
+ * Anonymous — no customer account required. The short form captures only what
+ * the package does not already state. Package/operator names are denormalised
+ * from the package at submit time so the lead is self-contained.
+ *
+ * Task 3 will add a marketing opt-in + consent record — leave structural room
+ * here (a `marketingOptIn` boolean + a separate consent record); do not inline
+ * it now.
+ */
+export interface Enquiry {
+  id: string;
+  referenceCode: string;
+  createdAt: string; // ISO date
+  packageId: string;
+  operatorId?: string;
+  packageTitle?: string;
+  operatorName?: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  travelMonth?: string;
+  message?: string;
+}
+
 export type BookingStatus = 'started' | 'contacted' | 'confirmed' | 'closed';
 
 export type BookingOutcomeType =

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -75,9 +75,46 @@ export const interestSchema = z.object({
   type: z.enum(['hajj', 'umrah'] as const),
 });
 
+/**
+ * Canonical pilgrim enquiry (Task 2). Short form — only fields the package does
+ * NOT already state. Name is required; at least one of email/phone is required
+ * so the operator can reply. travelMonth + message are optional.
+ *
+ * Task 3 will add a separate, unticked marketing opt-in here — leave room, do
+ * not inline it now.
+ */
+export const enquirySchema = z
+  .object({
+    packageId: z.string().trim().min(1, 'A package is required.'),
+    operatorId: z.string().trim().optional(),
+    name: z
+      .string()
+      .trim()
+      .min(1, 'Please enter your name.')
+      .max(100, 'Name must be 100 characters or fewer.'),
+    email: z
+      .string()
+      .trim()
+      .max(254, 'Email must be 254 characters or fewer.')
+      .email('Enter a valid email address.')
+      .optional()
+      .or(z.literal('')),
+    phone: z.string().trim().max(40, 'Phone must be 40 characters or fewer.').optional().or(z.literal('')),
+    travelMonth: z.string().trim().max(40, 'Travel month must be 40 characters or fewer.').optional(),
+    message: z.string().trim().max(1000, 'Message must be 1000 characters or fewer.').optional(),
+  })
+  .refine(
+    (d) => Boolean(d.email && d.email.length > 0) || Boolean(d.phone && d.phone.length > 0),
+    {
+      message: 'Add an email or phone number so the operator can reply.',
+      path: ['email'],
+    }
+  );
+
 export type SignUpInput = z.infer<typeof signUpSchema>;
 export type SignInInput = z.infer<typeof signInSchema>;
 export type InterestInput = z.infer<typeof interestSchema>;
+export type EnquiryInput = z.infer<typeof enquirySchema>;
 
 // ─── Reusable utility validators (non-Zod) ───────────────────────────────────
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -469,3 +469,23 @@ model Complaint {
 
   @@map("complaints")
 }
+
+/// Canonical pilgrim enquiry (one package, one enquiry, one operator).
+/// Anonymous — no customer FK. Captures the short enquiry form + reference code.
+/// Marketing opt-in / consent record is intentionally NOT here yet (Task 3).
+model Enquiry {
+  id            String   @id @default(uuid())
+  referenceCode String   @unique @map("reference_code")
+  createdAt     DateTime @default(now()) @map("created_at")
+  packageId     String   @map("package_id")
+  operatorId    String?  @map("operator_id")
+  packageTitle  String?  @map("package_title")
+  operatorName  String?  @map("operator_name")
+  name          String
+  email         String?
+  phone         String?
+  travelMonth   String?  @map("travel_month")
+  message       String?
+
+  @@map("enquiries")
+}

--- a/supabase/migrations/010_enquiries_table.sql
+++ b/supabase/migrations/010_enquiries_table.sql
@@ -1,0 +1,23 @@
+-- Migration 010: enquiries table
+-- Stores the canonical pilgrim enquiry (Task 2: one package, one enquiry, one operator).
+-- Anonymous capture — no customer FK. Mirrors the Prisma `Enquiry` model.
+-- Marketing opt-in / consent columns are intentionally NOT here yet (Task 3).
+
+CREATE TABLE IF NOT EXISTS enquiries (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  reference_code TEXT        NOT NULL UNIQUE,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  package_id     TEXT        NOT NULL,
+  operator_id    TEXT,
+  package_title  TEXT,
+  operator_name  TEXT,
+  name           TEXT        NOT NULL,
+  email          TEXT,
+  phone          TEXT,
+  travel_month   TEXT,
+  message        TEXT
+);
+
+-- RLS: service role only. Enquiries are written server-side via the service-role
+-- key (no public reads/writes). No public policies are added.
+ALTER TABLE enquiries ENABLE ROW LEVEL SECURITY;

--- a/tests/enquiry-api.test.ts
+++ b/tests/enquiry-api.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('next/server', () => {
+  const NextResponse = {
+    json: (body: unknown, init?: { status?: number }) => ({
+      _body: body,
+      _status: init?.status ?? 200,
+      json: async () => body,
+      status: init?.status ?? 200,
+    }),
+  };
+  return { NextResponse, NextRequest: class {} };
+});
+
+vi.mock('@/lib/rate-limit', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/rate-limit')>('@/lib/rate-limit');
+  return {
+    ...actual,
+    checkRateLimit: vi.fn(() => ({ limited: false })),
+    getRateLimitIdentifier: vi.fn(() => 'test-identifier'),
+  };
+});
+
+const sendEnquiryConfirmation = vi.fn(() => Promise.resolve());
+const sendOperatorEnquiryAlert = vi.fn(() => Promise.resolve());
+vi.mock('@/lib/email/send', () => ({ sendEnquiryConfirmation, sendOperatorEnquiryAlert }));
+
+const publishedPackage = {
+  id: 'pkg-1',
+  status: 'published',
+  title: '10-night Umrah from London',
+  operatorId: 'op-1',
+};
+const operator = { id: 'op-1', companyName: 'Al Amanah Travel', tradingName: 'Al Amanah', contactEmail: 'leads@alamanah.example' };
+
+const createEnquiry = vi.fn((input: Record<string, unknown>) =>
+  Promise.resolve({ id: 'enq-1', referenceCode: 'KT-ABCD1234', createdAt: '2026-06-15T00:00:00.000Z', ...input })
+);
+
+vi.mock('@/lib/api/repository', () => ({
+  Repository: {
+    getPackageById: vi.fn((id: string) => Promise.resolve(id === 'pkg-1' ? publishedPackage : undefined)),
+    getOperatorById: vi.fn(() => Promise.resolve(operator)),
+    createEnquiry: (input: Record<string, unknown>) => createEnquiry(input),
+  },
+}));
+
+const makeRequest = (body: unknown) => ({ json: async () => body, headers: { get: () => null } });
+
+async function callRoute(body: unknown) {
+  const { POST } = await import('@/app/api/enquiries/route');
+  const res = await POST(makeRequest(body) as never);
+  return { body: (res as unknown as { _body: Record<string, unknown> })._body, status: (res as unknown as { _status: number })._status };
+}
+
+describe('/api/enquiries route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('returns 201 with a reference code for a valid enquiry', async () => {
+    const { body, status } = await callRoute({ packageId: 'pkg-1', name: 'Aisha Khan', email: 'aisha@example.com', travelMonth: 'March 2026' });
+    expect(status).toBe(201);
+    expect(body.referenceCode).toBe('KT-ABCD1234');
+  });
+
+  it('persists package + operator names resolved server-side (not from client)', async () => {
+    await callRoute({ packageId: 'pkg-1', name: 'Aisha', phone: '07700 900000', packageTitle: 'HACK', operatorName: 'HACK' });
+    expect(createEnquiry).toHaveBeenCalledWith(
+      expect.objectContaining({ packageTitle: '10-night Umrah from London', operatorName: 'Al Amanah', operatorId: 'op-1' })
+    );
+  });
+
+  it('fires pilgrim confirmation + operator alert emails', async () => {
+    await callRoute({ packageId: 'pkg-1', name: 'Aisha', email: 'aisha@example.com' });
+    // allow the fire-and-forget microtask to run
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sendEnquiryConfirmation).toHaveBeenCalledTimes(1);
+    expect(sendOperatorEnquiryAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const { status } = await callRoute({ packageId: 'pkg-1', email: 'a@example.com' });
+    expect(status).toBe(400);
+  });
+
+  it('returns 400 when neither email nor phone provided', async () => {
+    const { status, body } = await callRoute({ packageId: 'pkg-1', name: 'Aisha' });
+    expect(status).toBe(400);
+    expect(String(body.error)).toContain('email or phone');
+  });
+
+  it('returns 404 for an unknown / unpublished package', async () => {
+    const { status } = await callRoute({ packageId: 'nope', name: 'Aisha', email: 'a@example.com' });
+    expect(status).toBe(404);
+  });
+});

--- a/tests/enquiry.test.ts
+++ b/tests/enquiry.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { enquirySchema } from '@/lib/validation';
+import { Repository } from '@/lib/api/repository';
+import { MockDB } from '@/lib/api/mock-db';
+
+describe('enquirySchema', () => {
+  const base = { packageId: 'pkg-1', name: 'Aisha Khan', email: 'aisha@example.com' };
+
+  it('accepts name + email', () => {
+    expect(enquirySchema.safeParse(base).success).toBe(true);
+  });
+
+  it('accepts name + phone (no email)', () => {
+    const r = enquirySchema.safeParse({ packageId: 'pkg-1', name: 'Aisha', phone: '07700 900000' });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects missing name', () => {
+    const r = enquirySchema.safeParse({ packageId: 'pkg-1', email: 'a@example.com' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects when neither email nor phone given', () => {
+    const r = enquirySchema.safeParse({ packageId: 'pkg-1', name: 'Aisha' });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error.issues[0].message).toContain('email or phone');
+  });
+
+  it('rejects an invalid email', () => {
+    const r = enquirySchema.safeParse({ packageId: 'pkg-1', name: 'Aisha', email: 'not-an-email' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects missing packageId', () => {
+    const r = enquirySchema.safeParse({ name: 'Aisha', email: 'a@example.com' });
+    expect(r.success).toBe(false);
+  });
+
+  it('leaves travelMonth and message optional', () => {
+    const r = enquirySchema.safeParse({ ...base, travelMonth: '', message: '' });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('Repository.createEnquiry', () => {
+  beforeEach(() => {
+    MockDB.getEnquiries().length = 0; // ensure isolation in shared in-memory store
+  });
+
+  it('issues a KT- reference code and persists the enquiry', async () => {
+    const enquiry = await Repository.createEnquiry({
+      packageId: 'pkg-1',
+      operatorId: 'op-1',
+      packageTitle: '10-night Umrah',
+      operatorName: 'Al Amanah Travel',
+      name: 'Aisha Khan',
+      email: 'aisha@example.com',
+      travelMonth: 'March 2026',
+    });
+
+    expect(enquiry.referenceCode).toMatch(/^KT-[A-Z0-9]{8}$/);
+    expect(enquiry.id).toBeTruthy();
+    expect(enquiry.createdAt).toBeTruthy();
+
+    const stored = await Repository.getEnquiries?.() ?? MockDB.getEnquiries();
+    const found = stored.find((e) => e.id === enquiry.id);
+    expect(found).toBeDefined();
+    expect(found?.packageId).toBe('pkg-1');
+    expect(found?.operatorName).toBe('Al Amanah Travel');
+    expect(found?.email).toBe('aisha@example.com');
+  });
+
+  it('issues unique reference codes across enquiries', async () => {
+    const a = await Repository.createEnquiry({ packageId: 'p', name: 'A', email: 'a@example.com' });
+    const b = await Repository.createEnquiry({ packageId: 'p', name: 'B', phone: '07700 900111' });
+    expect(a.referenceCode).not.toBe(b.referenceCode);
+  });
+
+  it('normalises blank optional fields to undefined', async () => {
+    const enquiry = await Repository.createEnquiry({
+      packageId: 'p',
+      name: '  Aisha  ',
+      phone: '07700 900222',
+      travelMonth: '   ',
+      message: '',
+    });
+    expect(enquiry.name).toBe('Aisha');
+    expect(enquiry.travelMonth).toBeUndefined();
+    expect(enquiry.message).toBeUndefined();
+    expect(enquiry.email).toBeUndefined();
+  });
+});

--- a/tests/enquiry.test.ts
+++ b/tests/enquiry.test.ts
@@ -62,7 +62,7 @@ describe('Repository.createEnquiry', () => {
     expect(enquiry.id).toBeTruthy();
     expect(enquiry.createdAt).toBeTruthy();
 
-    const stored = await Repository.getEnquiries?.() ?? MockDB.getEnquiries();
+    const stored = MockDB.getEnquiries();
     const found = stored.find((e) => e.id === enquiry.id);
     expect(found).toBeDefined();
     expect(found?.packageId).toBe('pkg-1');


### PR DESCRIPTION
## Task 2 — canonical pilgrim enquiry journey

One package, one enquiry, one operator. **Anonymous** (no login). Branched off `dev`.

### Flow
Package page **Enquire** CTA → `/packages/[slug]/enquire` → short form → `POST /api/enquiries` → confirmation screen.

### Fields (only these)
- **Name** (required)
- **Email and/or Phone** (≥1 required)
- **Travel month** (optional)
- **Message** (optional)

The form shows the package + operator **read-only** and never re-asks trip type, departure airport, duration, hotel rating, or budget. No marketing opt-in (that's Task 3 — structural room left).

### On submit
- Persists a new **`Enquiry`** (package + operator, pilgrim details, **unique `KT-` reference code**, timestamp) through the normal Repository/adapter/MockDB stack. New `enquiries` table via migration `010` (RLS, service-role only) — **already applied to Supabase**.
- Reuses the existing `generateReferenceCode` (no duplicate logic).
- Sends pilgrim confirmation + operator alert via the **existing Resend** setup, fire-and-forget (email never blocks persistence/confirmation).
- Confirmation screen shows the reference code, a "what happens next" line, and the **three verbatim payment-posture lines** (`PAYMENT_POSTURE_LINES`).

### Constraints honoured
- Parked `FEATURE_BOOKING_FLOW` / `FEATURE_RFQ_QUOTE` untouched (default OFF); parked RFQ CTA blocks left intact alongside the new Enquire CTA.
- No new deps. No marketing opt-in / lead-counting UI. Honest "Not provided" fallbacks. `docs/THEME-KNOWLEDGE.md` left untouched.

### Verification
- Vitest **1,852/1,852** (+16) · `tsc` clean · `npm run build` 0 errors
- Enquiry E2E **3/3 ×3 browsers** (serial). Full suite green apart from a pre-existing webkit `operator.spec.ts` flake (passes 10/10 in isolation; unrelated to this task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)