### PR TITLE
feat(enquiry): marketing email opt-in + contact-hint UX fix (Task 3)

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1,15 +1,48 @@
 # PilgrimCompare AI Handover — Single Source of Truth
 
-**Last verified:** 2026-06-15 (Task 2 — pilgrim enquiry journey — Vitest 1,852/1,852, `tsc` clean, 0 build errors, enquiry E2E 3/3 ×3 browsers serial)
-**Branch:** `feature/clean-enquiry-journey`
+**Last verified:** 2026-06-16 (Task 3 — pilgrim email opt-in + contact-hint — Vitest 1,860/1,860, `tsc` clean, 0 build errors; migration 011 applied to Supabase)
+**Branch:** `feature/pilgrim-email-optin` (off `dev` `314f303`; Task 2 merged via PR #86)
 **Audience:** Claude, Codex, Kimi, and any AI/developer taking over the project.
 
 **Next immediate action:**
-Task 3 — compliant pilgrim email opt-in (direction file §9). Add a separate, unticked marketing opt-in to the enquiry form with a stored consent record (timestamp, source, exact wording) + unsubscribe/suppression. Structural room already left in `lib/validation.ts` (`enquirySchema`), `lib/types.ts` (`Enquiry`), `components/enquiry/EnquiryForm.tsx`, and migration `010`.
+Task 4 — lead logging + per-operator enquiry counting (analytics event on enquiry). `Repository.createEnquiry` is currently pure persistence — no analytics/lead-count event is emitted yet. Also: wire the double-opt-in confirmation send + unsubscribe/suppression on top of the `marketing_consents` store built in Task 3 (record exists; no email is sent yet, by design).
 
 This file is the current handover source of truth. If another document conflicts with a verified statement here, treat that other document as stale and update it before changing implementation.
 
 > **Precedence note (2026-06-15):** `PILGRIMCOMPARE_PROJECT_DIRECTION.md` (repo root) is now the single source of truth for product direction and **must be read first every session**, before this file. It wins all conflicts except the language/legal red lines. `PARKED_FEATURES.md` (repo root) is the canonical parked-feature register.
+
+---
+
+## §Task 3 — Pilgrim email opt-in + contact-hint UX fix — 2026-06-16
+
+**Status: ✅ COMPLETE on branch `feature/pilgrim-email-optin`** (off `dev` `314f303`). Vitest **1,860/1,860** (+8), `tsc` clean, `npm run build` 0 errors. Migration `011` **applied to Supabase** (verified: 7 cols, RLS on, `enquiry_reference` NOT NULL, unique constraint present). No email sent from this task — store only.
+
+### What was built
+1. **Marketing opt-in on the enquiry form** (`components/enquiry/EnquiryForm.tsx`): a single, **unticked-by-default** consent checkbox (`data-testid="enquiry-marketing-consent"`) below the contact fields. Verbatim UK-English label: *"Email me Umrah tips and package updates from PilgrimCompare. You can unsubscribe anytime."* Consent is **optional** — the enquiry sends regardless; marketing consent never blocks it.
+2. **Contact-hint UX fix** (the flagged Task-2 item): when name is filled but neither email nor phone given, a visible hint `data-testid="enquiry-contact-hint"` ("Add an email or phone to send.") shows near the Send button. **Additive** — the existing disabled-button behaviour (`canSubmit`) is unchanged.
+
+### New table + RLS decision
+- **Dedicated `marketing_consents` table** (migration `supabase/migrations/011_marketing_consents_table.sql`) — consent is **NOT** bolted onto the `enquiries` record. RLS **enabled, service-role only, no public policies** — consistent with `enquiries`/`interests` (the existing 12-table RLS model). Prisma model `MarketingConsent` (`@@map("marketing_consents")`).
+- Columns: `id, email NOT NULL, consent BOOLEAN NOT NULL DEFAULT true, consent_timestamp TIMESTAMPTZ, source TEXT NOT NULL DEFAULT 'enquiry_form', enquiry_reference TEXT NOT NULL, created_at`. `UNIQUE (email, enquiry_reference)` for idempotency.
+- **`enquiry_reference` is NOT NULL** (founder correction): every write carries the KT- reference, so the unique constraint always dedupes (Postgres treats NULLs as distinct — avoided here). The write path (`route.ts`) always passes `enquiry.referenceCode`.
+- **Semantics (founder correction):** a row exists **only** when consent was given **with an email**. The **absence of a row IS the "no consent" state** — there is no `consent=false` row. `consent` is kept TRUE purely for audit explicitness.
+
+### Consent data shape
+`MarketingConsent` (`lib/types.ts`): `{ id, email, consent (always true), consentTimestamp (ISO/UTC), source ('enquiry_form'), enquiryReference (KT- code), createdAt }`.
+
+### Gating logic (in `app/api/enquiries/route.ts`)
+After `createEnquiry`, persist consent **only when** `marketingConsent === true` **AND** `enquiry.email` present. Phone-only opt-in → **no record**. The consent write is wrapped in try/catch and **logs but never propagates** to the enquiry response (the 201 + reference code always returns). Double-opt-in ready: stored only; **no email sent here**.
+
+### Files changed
+`supabase/migrations/011_marketing_consents_table.sql` (new), `prisma/schema.prisma` (`MarketingConsent` model), `lib/types.ts` (`MarketingConsent`), `lib/validation.ts` (`enquirySchema.marketingConsent: boolean, default false`), `lib/api/mock-db.ts` (`MARKETING_CONSENTS` key + get/save, idempotent), `lib/api/db/adapter.ts` (`mapMarketingConsent` + get/save upsert on the compound unique), `lib/api/repository.ts` (mockStore wiring + `createMarketingConsent`), `app/api/enquiries/route.ts` (gated consent persist). Tests: `tests/enquiry-api.test.ts` (+4: sends unticked w/ no record; record only ticked+email; none ticked+phone-only; consent failure never fails enquiry), `tests/enquiry.test.ts` (+4: schema default/true, repository persist + idempotency), `e2e/enquiry.spec.ts` (hint appears name-only then disappears; submit ±checkbox).
+
+### Hard rules held
+KT- reference prefix **untouched** (logged separately). The three payment-posture lines on the confirmation screen **unchanged**. Parked flags (`FEATURE_BOOKING_FLOW`/`FEATURE_RFQ_QUOTE`) untouched. Missing data still shows "Not provided".
+
+### Open risks / notes
+- Migration applied via `npx prisma db execute --file …` (uses `DIRECT_URL` from `prisma.config.ts`); `psql` not installed on this box. Additive + idempotent (`CREATE TABLE IF NOT EXISTS`).
+- E2E not run locally this session (CI runs no Playwright; full suite is run manually pre-merge per §9). The two enquiry E2E flows are written and the build that serves them is green. Run `npx playwright test e2e/enquiry.spec.ts` before merge if desired.
+- No unsubscribe/suppression UI or send yet — that's Task 4 (the store is the prerequisite, now in place).
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,17 +3,17 @@
 > **Single rolling tracker.** Any AI/dev: read this for current state. Update it after work is **done + tested + verified** (see `CLAUDE.md` rule).
 > Detailed handover lives in `AI_NOTES.md`. Cold-start brief: `HANDOFF.md`. Business: `BUSINESS.md`.
 
-**Last verified:** 2026-06-15 (cookie-banner E2E flake fix) · **Branch:** `feature/fix-cookie-banner-e2e-flake` · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
+**Last verified:** 2026-06-16 (Task 3 — pilgrim email opt-in + contact-hint) · **Branch:** `feature/pilgrim-email-optin` (PR → `dev`, open) · **App:** Next.js 15.5 / React 19 / Supabase / Prisma
 
 > **Direction:** `PILGRIMCOMPARE_PROJECT_DIRECTION.md` (repo root) is now the source of truth — read first every session. Parked features tracked in `PARKED_FEATURES.md`.
 
 ---
 
-## Health (verified 2026-06-15)
+## Health (verified 2026-06-16)
 
 | Check | State |
 | --- | --- |
-| `npm run test` | ✅ 1,836/1,836 pass (29 files) |
+| `npm run test` | ✅ 1,860/1,860 pass (31 files) |
 | `npm run build` | ✅ 0 errors |
 | `npx tsc --noEmit` | ✅ pass |
 | E2E | ✅ cookie-banner click-intercept flake fixed 2026-06-15 (`feature/fix-cookie-banner-e2e-flake`, AI_NOTES §Cookie-banner E2E flake fix). `catalogue`/`operator`/`bank-payment` 45/45 × 3 serial runs (chromium+firefox+webkit). |
@@ -25,6 +25,8 @@
 ## ✅ Done (shipped & verified)
 
 **Direction & parked flows**
+- **Task 3 — pilgrim email opt-in + contact-hint UX fix (2026-06-16, branch `feature/pilgrim-email-optin`, see AI_NOTES §Task 3):** unticked-by-default marketing consent checkbox on the enquiry form (verbatim label; optional — never blocks the enquiry). New dedicated `marketing_consents` table (migration `011`, applied to Supabase, RLS service-role only, `enquiry_reference NOT NULL`, unique `(email, enquiry_reference)`). Consent persisted **only** when ticked AND email present; phone-only → no record; absence of row = no consent. Consent write wrapped — never fails the enquiry. No email sent (double-opt-in-ready store only). Also: contact-hint near Send when name-only ("Add an email or phone to send."). KT- prefix + payment-posture lines untouched.
+- **Task 2 — canonical pilgrim enquiry journey (2026-06-15, merged via PR #86, see AI_NOTES §Task 2):** anonymous package→Enquire→short form→KT- reference + confirmation with the three payment-posture lines. New `Enquiry` entity (migration `010`), `POST /api/enquiries` (IP rate-limited), confirmation + operator-alert emails fire-and-forget via existing Resend.
 - **Task 1 — parked the broken flows (2026-06-15, branch `feature/park-rfq-booking-flows`, see AI_NOTES §Task 1):** added two server-side feature flags in `lib/config.ts`, both **default OFF**, removing them from the live pilgrim journey without deleting any code. `FEATURE_RFQ_QUOTE` (`isRfqQuoteEnabled`) — `/quote` wizard 404s, package "Request quote" CTA + footer/corridor/umrah `/quote` links hidden, quote-request POST 404s. `FEATURE_BOOKING_FLOW` (`isBookingFlowEnabled`) — "Proceed direct"/booking dialog/payment-evidence/operator bank details hidden, confirmation page + booking-intent POST 404. Created `PILGRIMCOMPARE_PROJECT_DIRECTION.md` + `PARKED_FEATURES.md`. Acceptance verified on a 375px live preview (flags OFF). Playwright forces both flags ON so parked code stays E2E-covered; `tests/feature-flags.test.tsx` covers flag-OFF.
 
 **Traveller flow**

--- a/app/api/enquiries/route.ts
+++ b/app/api/enquiries/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
     }
 
-    const { packageId, name, email, phone, travelMonth, message } = parsed.data;
+    const { packageId, name, email, phone, travelMonth, message, marketingConsent } = parsed.data;
 
     // Resolve the package + operator server-side so the lead carries honest,
     // package-sourced names (never client-supplied). Reject unknown/unpublished.
@@ -50,6 +50,22 @@ export async function POST(request: NextRequest) {
       travelMonth: travelMonth || undefined,
       message: message || undefined,
     });
+
+    // Task 3: capture marketing consent ONLY when opted in AND an email was
+    // given (consent requires an email to be actionable). Phone-only opt-in is
+    // ignored — no record. Wrapped so a consent-store failure can never fail the
+    // enquiry response. Double-opt-in ready: stored only, no email sent here.
+    if (marketingConsent && enquiry.email) {
+      try {
+        await Repository.createMarketingConsent({
+          email: enquiry.email,
+          enquiryReference: enquiry.referenceCode,
+          source: 'enquiry_form',
+        });
+      } catch (err) {
+        console.error('[enquiry] marketing consent persist failed:', err);
+      }
+    }
 
     // Fire-and-forget: emails must not fail the API response.
     void sendEnquiryEmails(enquiry, pkg, operator);

--- a/components/enquiry/EnquiryForm.tsx
+++ b/components/enquiry/EnquiryForm.tsx
@@ -35,12 +35,15 @@ export function EnquiryForm({ summary, packageSlug }: EnquiryFormProps) {
   const [phone, setPhone] = useState('')
   const [travelMonth, setTravelMonth] = useState('')
   const [message, setMessage] = useState('')
+  const [marketingOptIn, setMarketingOptIn] = useState(false)
   const [submit, setSubmit] = useState<SubmitState>({ status: 'idle' })
   const [referenceCode, setReferenceCode] = useState<string | null>(null)
 
   // Client-side mirror of the server rule: name + at least one contact.
   const hasContact = email.trim().length > 0 || phone.trim().length > 0
   const canSubmit = name.trim().length > 0 && hasContact && submit.status !== 'submitting'
+  // Task 3 UX fix: name filled but no contact yet → nudge near the Send button.
+  const showContactHint = name.trim().length > 0 && !hasContact
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -60,6 +63,7 @@ export function EnquiryForm({ summary, packageSlug }: EnquiryFormProps) {
           phone: phone.trim(),
           travelMonth: travelMonth.trim(),
           message: message.trim(),
+          marketingConsent: marketingOptIn,
         }),
       })
       const data = (await res.json().catch(() => ({}))) as { referenceCode?: string; error?: string }
@@ -216,7 +220,27 @@ export function EnquiryForm({ summary, packageSlug }: EnquiryFormProps) {
           />
         </Field>
 
-        {/* Task 3: a separate, unticked marketing opt-in goes here. */}
+        {/* Task 3: separate, OPTIONAL, unticked-by-default marketing opt-in.
+            Persisted only when ticked AND an email is given — never blocks the enquiry. */}
+        <label htmlFor="enquiry-marketing-consent" className="flex items-start gap-3 rounded-lg border border-[var(--border)] p-4">
+          <input
+            id="enquiry-marketing-consent"
+            data-testid="enquiry-marketing-consent"
+            type="checkbox"
+            checked={marketingOptIn}
+            onChange={(e) => setMarketingOptIn(e.target.checked)}
+            className="mt-0.5 h-4 w-4 shrink-0 accent-[var(--yellow)]"
+          />
+          <span className="text-sm leading-relaxed text-[var(--textMuted)]">
+            Email me Umrah tips and package updates from PilgrimCompare. You can unsubscribe anytime.
+          </span>
+        </label>
+
+        {showContactHint && (
+          <p data-testid="enquiry-contact-hint" role="status" className="text-sm text-[var(--textMuted)]">
+            Add an email or phone to send.
+          </p>
+        )}
 
         {submit.status === 'error' && (
           <p data-testid="enquiry-error" role="alert" className="text-sm text-[var(--danger)]">

--- a/e2e/enquiry.spec.ts
+++ b/e2e/enquiry.spec.ts
@@ -24,7 +24,15 @@ test('Pilgrim enquiry journey: package → enquire → confirmation', async ({ p
   await expect(page.locator('[data-testid="enquiry-package-summary"]')).toBeVisible();
 
   await page.locator('[data-testid="enquiry-name"]').fill('Aisha Khan');
+
+  // Task 3 UX fix: name filled, no contact yet → hint shows; gone once a contact added.
+  await expect(page.locator('[data-testid="enquiry-contact-hint"]')).toBeVisible();
+  await expect(page.locator('[data-testid="enquiry-contact-hint"]')).toContainText('Add an email or phone to send.');
   await page.locator('[data-testid="enquiry-email"]').fill('aisha@example.com');
+  await expect(page.locator('[data-testid="enquiry-contact-hint"]')).toHaveCount(0);
+
+  // Task 3: marketing opt-in unticked by default; submit succeeds WITHOUT ticking it.
+  await expect(page.locator('[data-testid="enquiry-marketing-consent"]')).not.toBeChecked();
   await page.locator('[data-testid="enquiry-submit"]').click();
 
   // Confirmation: reference code + payment-posture copy.
@@ -36,4 +44,33 @@ test('Pilgrim enquiry journey: package → enquire → confirmation', async ({ p
   await expect(page.locator('[data-testid="enquiry-payment-posture"]')).toContainText(
     'a tracking code, not a payment receipt'
   );
+});
+
+// Task 3: the enquiry also submits WITH the marketing opt-in ticked.
+test('Pilgrim enquiry journey: submits with marketing opt-in ticked', async ({ page }) => {
+  await dismissCookieBanner(page);
+
+  await page.goto('/packages');
+  const firstPackageLink = page.locator('[data-testid^="package-view-"]').first();
+  await expect(firstPackageLink).toBeVisible();
+  await Promise.all([page.waitForURL('**/packages/**'), firstPackageLink.click()]);
+  await page.waitForLoadState('domcontentloaded');
+
+  const enquireCta = page.locator('[data-testid="package-cta-enquire"]');
+  await expect(enquireCta).toBeVisible();
+  await Promise.all([page.waitForURL('**/enquire'), enquireCta.click()]);
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.locator('[data-testid="enquiry-form-page"]')).toBeVisible();
+
+  await page.locator('[data-testid="enquiry-name"]').fill('Yusuf Ali');
+  await page.locator('[data-testid="enquiry-email"]').fill('yusuf@example.com');
+
+  const optIn = page.locator('[data-testid="enquiry-marketing-consent"]');
+  await expect(optIn).not.toBeChecked();
+  await optIn.check();
+  await expect(optIn).toBeChecked();
+
+  await page.locator('[data-testid="enquiry-submit"]').click();
+  await expect(page.locator('[data-testid="enquiry-confirmation"]')).toBeVisible();
+  await expect(page.locator('[data-testid="enquiry-reference-code"]')).toContainText(/KT-/);
 });

--- a/lib/api/db/adapter.ts
+++ b/lib/api/db/adapter.ts
@@ -7,6 +7,7 @@ import type {
   BookingIntent,
   Complaint,
   Enquiry,
+  MarketingConsent,
   Offer,
   OperatorProfile,
   Package,
@@ -26,6 +27,7 @@ import type {
   AnalyticsEventModel as PrismaAnalyticsEvent,
   ComplaintModel as PrismaComplaint,
   EnquiryModel as PrismaEnquiry,
+  MarketingConsentModel as PrismaMarketingConsent,
 } from '@/lib/generated/prisma/models';
 
 // ─── Helpers ─────────────────────────────────────────────────────────
@@ -159,6 +161,16 @@ const mapEnquiry = (e: PrismaEnquiry): Enquiry => ({
   phone: e.phone ?? undefined,
   travelMonth: e.travelMonth ?? undefined,
   message: e.message ?? undefined,
+});
+
+const mapMarketingConsent = (c: PrismaMarketingConsent): MarketingConsent => ({
+  id: c.id,
+  email: c.email,
+  consent: c.consent,
+  consentTimestamp: c.consentTimestamp.toISOString(),
+  source: c.source,
+  enquiryReference: c.enquiryReference,
+  createdAt: c.createdAt.toISOString(),
 });
 
 const mapOffer = (o: PrismaOffer): Offer => ({
@@ -627,6 +639,28 @@ export const DBAdapter = {
       update: data,
     });
     return mapEnquiry(saved);
+  },
+
+  // Marketing consents (Task 3). Idempotent on (email, enquiryReference).
+  getMarketingConsents: async (): Promise<MarketingConsent[]> =>
+    (await prisma.marketingConsent.findMany()).map(mapMarketingConsent),
+
+  saveMarketingConsent: async (consent: MarketingConsent): Promise<MarketingConsent> => {
+    const data = {
+      email: consent.email,
+      consent: consent.consent,
+      consentTimestamp: dateOrNow(consent.consentTimestamp),
+      source: consent.source,
+      enquiryReference: consent.enquiryReference,
+    };
+    const saved = await prisma.marketingConsent.upsert({
+      where: {
+        email_enquiryReference: { email: consent.email, enquiryReference: consent.enquiryReference },
+      },
+      create: { id: consent.id, ...data, createdAt: dateOrNow(consent.createdAt) },
+      update: data,
+    });
+    return mapMarketingConsent(saved);
   },
 
   // Transaction support

--- a/lib/api/mock-db.ts
+++ b/lib/api/mock-db.ts
@@ -6,6 +6,7 @@ import {
   BookingOutcome,
   Complaint,
   Enquiry,
+  MarketingConsent,
   Offer,
   OperatorProfile,
   Package,
@@ -30,6 +31,7 @@ const STORAGE_KEYS = {
   COMPLAINTS: 'kb_complaints',
   INTERESTS: 'kb_interests',
   ENQUIRIES: 'kb_enquiries',
+  MARKETING_CONSENTS: 'kb_marketing_consents',
 };
 
 const PACKAGES_SEED_VERSION = 5;
@@ -1158,6 +1160,25 @@ export const MockDB = {
     }
     setStorage(STORAGE_KEYS.ENQUIRIES, enquiries);
     return enquiry;
+  },
+
+  // Task 3: marketing consent (a row exists only when consent given + email present).
+  getMarketingConsents: (): MarketingConsent[] =>
+    getStorage<MarketingConsent[]>(STORAGE_KEYS.MARKETING_CONSENTS, []),
+
+  saveMarketingConsent: (consent: MarketingConsent) => {
+    const consents = MockDB.getMarketingConsents();
+    // Idempotent on (email, enquiryReference) — mirror the DB unique constraint.
+    const existingIndex = consents.findIndex(
+      (c) => c.email === consent.email && c.enquiryReference === consent.enquiryReference
+    );
+    if (existingIndex >= 0) {
+      consents[existingIndex] = consent;
+    } else {
+      consents.push(consent);
+    }
+    setStorage(STORAGE_KEYS.MARKETING_CONSENTS, consents);
+    return consent;
   },
 
   getBookingOutcomes: (): BookingOutcome[] =>

--- a/lib/api/repository.ts
+++ b/lib/api/repository.ts
@@ -20,6 +20,7 @@ import {
   ComplaintSeverity,
   ComplaintStatus,
   Enquiry,
+  MarketingConsent,
   Offer,
   OperatorProfile,
   Package,
@@ -66,6 +67,8 @@ const mockStore = {
   deletePackage: (id: string) => Promise.resolve(MockDB.deletePackage(id)),
   getEnquiries: () => Promise.resolve(MockDB.getEnquiries()),
   saveEnquiry: (enquiry: Enquiry) => Promise.resolve(MockDB.saveEnquiry(enquiry)),
+  getMarketingConsents: () => Promise.resolve(MockDB.getMarketingConsents()),
+  saveMarketingConsent: (consent: MarketingConsent) => Promise.resolve(MockDB.saveMarketingConsent(consent)),
   getBookingOutcomes: () => Promise.resolve(MockDB.getBookingOutcomes()),
   saveBookingOutcome: (bo: BookingOutcome) => Promise.resolve(MockDB.saveBookingOutcome(bo)),
   getDistinctDepartureCities: (): Promise<string[]> => {
@@ -562,6 +565,27 @@ export const Repository = {
     };
 
     return store().saveEnquiry(enquiry);
+  },
+
+  // Marketing consent (Task 3). Caller is responsible for the gating rule — a
+  // record is created ONLY when the pilgrim opted in AND an email is present
+  // (consent requires an email to be actionable). The enquiry reference is
+  // always carried so the DB unique (email, enquiry_reference) dedupes.
+  createMarketingConsent: async (input: {
+    email: string;
+    enquiryReference: string;
+    source?: string;
+  }): Promise<MarketingConsent> => {
+    const consent: MarketingConsent = {
+      id: crypto.randomUUID(),
+      email: input.email.trim(),
+      consent: true,
+      consentTimestamp: new Date().toISOString(),
+      source: input.source ?? 'enquiry_form',
+      enquiryReference: input.enquiryReference,
+      createdAt: new Date().toISOString(),
+    };
+    return store().saveMarketingConsent(consent);
   },
 
   // Quote Requests

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -255,6 +255,22 @@ export interface Enquiry {
   message?: string;
 }
 
+/**
+ * Task 3: explicit marketing email consent captured at enquiry time.
+ * A record exists ONLY when consent was given with an email — the absence of a
+ * record is the "no consent" state. `consent` is always true (audit explicitness).
+ * Double-opt-in ready: the record is stored; no email is sent from this flow.
+ */
+export interface MarketingConsent {
+  id: string;
+  email: string;
+  consent: boolean;
+  consentTimestamp: string; // ISO date (UTC)
+  source: string; // e.g. 'enquiry_form'
+  enquiryReference: string; // the KT- enquiry reference code
+  createdAt: string; // ISO date
+}
+
 export type BookingStatus = 'started' | 'contacted' | 'confirmed' | 'closed';
 
 export type BookingOutcomeType =

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -102,6 +102,9 @@ export const enquirySchema = z
     phone: z.string().trim().max(40, 'Phone must be 40 characters or fewer.').optional().or(z.literal('')),
     travelMonth: z.string().trim().max(40, 'Travel month must be 40 characters or fewer.').optional(),
     message: z.string().trim().max(1000, 'Message must be 1000 characters or fewer.').optional(),
+    // Task 3: OPTIONAL marketing opt-in. Defaults false; never blocks the enquiry.
+    // A consent record is persisted only when this is true AND an email is given.
+    marketingConsent: z.boolean().optional().default(false),
   })
   .refine(
     (d) => Boolean(d.email && d.email.length > 0) || Boolean(d.phone && d.phone.length > 0),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -489,3 +489,18 @@ model Enquiry {
 
   @@map("enquiries")
 }
+
+// Task 3: explicit marketing email consent captured at enquiry time.
+// A row exists ONLY when consent was given with an email — absence = no consent.
+model MarketingConsent {
+  id               String   @id @default(uuid())
+  email            String
+  consent          Boolean  @default(true)
+  consentTimestamp DateTime @default(now()) @map("consent_timestamp")
+  source           String   @default("enquiry_form")
+  enquiryReference String   @map("enquiry_reference")
+  createdAt        DateTime @default(now()) @map("created_at")
+
+  @@unique([email, enquiryReference], map: "marketing_consents_email_reference_unique")
+  @@map("marketing_consents")
+}

--- a/supabase/migrations/011_marketing_consents_table.sql
+++ b/supabase/migrations/011_marketing_consents_table.sql
@@ -1,0 +1,24 @@
+-- Migration 011: marketing_consents table (Task 3)
+-- Captures explicit, opt-in marketing email consent gathered at enquiry time.
+-- A row exists ONLY when the pilgrim ticked the opt-in AND gave an email — the
+-- ABSENCE of a row is the "no consent" state (there is no consent=false row).
+-- `consent` is kept TRUE for audit explicitness; the write path only ever inserts
+-- TRUE. Double-opt-in ready: this stores the record; no email is sent from here.
+-- Dedicated table — consent is NOT bolted onto the enquiry record.
+
+CREATE TABLE IF NOT EXISTS marketing_consents (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  email             TEXT        NOT NULL,
+  consent           BOOLEAN     NOT NULL DEFAULT true,
+  consent_timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+  source            TEXT        NOT NULL DEFAULT 'enquiry_form',
+  enquiry_reference TEXT        NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Idempotent per (email, enquiry). enquiry_reference is NOT NULL so the unique
+  -- constraint always dedupes (Postgres treats NULLs as distinct — avoided here).
+  CONSTRAINT marketing_consents_email_reference_unique UNIQUE (email, enquiry_reference)
+);
+
+-- RLS: service role only. Written server-side via the service-role key; no public
+-- reads/writes. No public policies added (mirrors enquiries / interests).
+ALTER TABLE marketing_consents ENABLE ROW LEVEL SECURITY;

--- a/tests/enquiry-api.test.ts
+++ b/tests/enquiry-api.test.ts
@@ -36,12 +36,16 @@ const operator = { id: 'op-1', companyName: 'Al Amanah Travel', tradingName: 'Al
 const createEnquiry = vi.fn((input: Record<string, unknown>) =>
   Promise.resolve({ id: 'enq-1', referenceCode: 'KT-ABCD1234', createdAt: '2026-06-15T00:00:00.000Z', ...input })
 );
+const createMarketingConsent = vi.fn((input: Record<string, unknown>) =>
+  Promise.resolve({ id: 'mc-1', consent: true, consentTimestamp: '2026-06-15T00:00:00.000Z', createdAt: '2026-06-15T00:00:00.000Z', ...input })
+);
 
 vi.mock('@/lib/api/repository', () => ({
   Repository: {
     getPackageById: vi.fn((id: string) => Promise.resolve(id === 'pkg-1' ? publishedPackage : undefined)),
     getOperatorById: vi.fn(() => Promise.resolve(operator)),
     createEnquiry: (input: Record<string, unknown>) => createEnquiry(input),
+    createMarketingConsent: (input: Record<string, unknown>) => createMarketingConsent(input),
   },
 }));
 
@@ -94,5 +98,35 @@ describe('/api/enquiries route', () => {
   it('returns 404 for an unknown / unpublished package', async () => {
     const { status } = await callRoute({ packageId: 'nope', name: 'Aisha', email: 'a@example.com' });
     expect(status).toBe(404);
+  });
+
+  // ─── Task 3: marketing opt-in ────────────────────────────────────────────
+  it('sends the enquiry with consent unticked and stores NO consent record', async () => {
+    const { status, body } = await callRoute({ packageId: 'pkg-1', name: 'Aisha', email: 'aisha@example.com' });
+    expect(status).toBe(201);
+    expect(body.referenceCode).toBe('KT-ABCD1234');
+    expect(createMarketingConsent).not.toHaveBeenCalled();
+  });
+
+  it('stores a consent record only when ticked AND an email is present', async () => {
+    const { status } = await callRoute({ packageId: 'pkg-1', name: 'Aisha', email: 'aisha@example.com', marketingConsent: true });
+    expect(status).toBe(201);
+    expect(createMarketingConsent).toHaveBeenCalledTimes(1);
+    expect(createMarketingConsent).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'aisha@example.com', enquiryReference: 'KT-ABCD1234', source: 'enquiry_form' })
+    );
+  });
+
+  it('stores NO consent record when ticked but phone-only (no email)', async () => {
+    const { status } = await callRoute({ packageId: 'pkg-1', name: 'Aisha', phone: '07700 900000', marketingConsent: true });
+    expect(status).toBe(201);
+    expect(createMarketingConsent).not.toHaveBeenCalled();
+  });
+
+  it('never fails the enquiry if the consent store throws', async () => {
+    createMarketingConsent.mockRejectedValueOnce(new Error('db down'));
+    const { status, body } = await callRoute({ packageId: 'pkg-1', name: 'Aisha', email: 'aisha@example.com', marketingConsent: true });
+    expect(status).toBe(201);
+    expect(body.referenceCode).toBe('KT-ABCD1234');
   });
 });

--- a/tests/enquiry.test.ts
+++ b/tests/enquiry.test.ts
@@ -90,3 +90,48 @@ describe('Repository.createEnquiry', () => {
     expect(enquiry.email).toBeUndefined();
   });
 });
+
+describe('enquirySchema — marketing opt-in (Task 3)', () => {
+  const base = { packageId: 'pkg-1', name: 'Aisha', email: 'aisha@example.com' };
+
+  it('defaults marketingConsent to false when omitted', () => {
+    const r = enquirySchema.safeParse(base);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.marketingConsent).toBe(false);
+  });
+
+  it('accepts marketingConsent true', () => {
+    const r = enquirySchema.safeParse({ ...base, marketingConsent: true });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.marketingConsent).toBe(true);
+  });
+});
+
+describe('Repository.createMarketingConsent (Task 3)', () => {
+  beforeEach(() => {
+    MockDB.getMarketingConsents().length = 0;
+  });
+
+  it('persists a consent record (consent=true, source, reference, UTC timestamp)', async () => {
+    const consent = await Repository.createMarketingConsent({
+      email: 'aisha@example.com',
+      enquiryReference: 'KT-ABCD1234',
+    });
+    expect(consent.consent).toBe(true);
+    expect(consent.source).toBe('enquiry_form');
+    expect(consent.enquiryReference).toBe('KT-ABCD1234');
+    expect(consent.consentTimestamp).toBeTruthy();
+
+    const stored = MockDB.getMarketingConsents();
+    expect(stored.find((c) => c.id === consent.id)?.email).toBe('aisha@example.com');
+  });
+
+  it('is idempotent on (email, enquiryReference) — no duplicate row', async () => {
+    await Repository.createMarketingConsent({ email: 'a@example.com', enquiryReference: 'KT-DUP00001' });
+    await Repository.createMarketingConsent({ email: 'a@example.com', enquiryReference: 'KT-DUP00001' });
+    const rows = MockDB.getMarketingConsents().filter(
+      (c) => c.email === 'a@example.com' && c.enquiryReference === 'KT-DUP00001'
+    );
+    expect(rows).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Task 3 — pilgrim email opt-in at enquiry time + contact-hint UX fix

Branched off `dev` (`314f303`, after Task 2 / PR #86 merged). **Do not merge** without review.

### What changed
1. **Marketing opt-in** on the enquiry form — a single, **unticked-by-default**, **optional** consent checkbox below the contact fields. Verbatim UK-English label: *"Email me Umrah tips and package updates from PilgrimCompare. You can unsubscribe anytime."* The enquiry sends regardless; consent never blocks it.
2. **Contact-hint UX fix** (flagged Task-2 item) — when name is filled but neither email nor phone is given, a visible hint *"Add an email or phone to send."* shows near the Send button. Additive; the existing disabled-button behaviour is unchanged.

### Consent store (decision)
- **Dedicated `marketing_consents` table** (migration `011`) — not bolted onto the enquiry record. **RLS enabled, service-role only, no public policies** (consistent with `enquiries`/`interests`).
- `enquiry_reference TEXT NOT NULL` + `UNIQUE (email, enquiry_reference)` → idempotent, no NULL-distinct gap.
- A row exists **only** when consent given **with an email**. Absence of a row IS the "no consent" state — there is no `consent=false` row (`consent` kept TRUE for audit clarity).
- Gating (`app/api/enquiries/route.ts`): persist consent **only when** ticked **AND** email present. Phone-only → no record. Write wrapped in try/catch — **never fails the enquiry**. **No email sent** — double-opt-in-ready store only.

### Hard rules held
KT- reference prefix untouched · 3 payment-posture lines unchanged · parked flags untouched · missing data = "Not provided".

### Verification
- Vitest **1,860/1,860** (+8) · `npx tsc --noEmit` clean · `npm run build` 0 errors.
- Migration `011` **applied to Supabase** (verified: 7 cols, RLS on, `enquiry_reference` NOT NULL, unique constraint present).
- E2E spec extended (hint show/hide; submit with and without the checkbox) — run `npx playwright test e2e/enquiry.spec.ts` pre-merge (CI runs no Playwright).

### Next (Task 4)
Lead logging + per-operator enquiry counting; double-opt-in confirmation send + unsubscribe/suppression on top of this store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)