### PR TITLE
chore(auth): idempotent app_metadata.role backfill + verifier

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1,7 +1,7 @@
 # PilgrimCompare AI Handover — Single Source of Truth
 
-**Last verified:** 2026-06-16 (Task C — KT-→PC- reference prefix rename — Vitest 1,860/1,860, `tsc` clean, 0 build errors, enquiry E2E 6/6 ×3 browsers). Task 3 merged to `dev` via PR #87 (merge `313c222`).
-**Branch:** `feature/reference-prefix-rename` (off `dev` `313c222`)
+**Last verified:** 2026-06-16 (Task E — `app_metadata.role` backfill — idempotent script ran clean against live: total 10, 0 absent, 0 updated, 10 skipped, breakdown unchanged 8 customer / 1 operator / 1 admin). Task C (KT-→PC-) + Task 3 merged to `dev`; Task D (Plausible) PR open to `dev`.
+**Branch:** `chore/app-metadata-role-backfill` (off `dev` `49640e2`)
 **Audience:** Claude, Codex, Kimi, and any AI/developer taking over the project.
 
 **Next immediate action:**
@@ -10,6 +10,40 @@ Task 4 — lead logging + per-operator enquiry counting (analytics event on enqu
 This file is the current handover source of truth. If another document conflicts with a verified statement here, treat that other document as stale and update it before changing implementation.
 
 > **Precedence note (2026-06-15):** `PILGRIMCOMPARE_PROJECT_DIRECTION.md` (repo root) is now the single source of truth for product direction and **must be read first every session**, before this file. It wins all conflicts except the language/legal red lines. `PARKED_FEATURES.md` (repo root) is the canonical parked-feature register.
+
+---
+
+## §Task E — `app_metadata.role` backfill — 2026-06-16
+
+**Status: ✅ COMPLETE on branch `chore/app-metadata-role-backfill`** (off `dev` `49640e2`). Closes the §5 / §8 P0 backfill item. No schema migration (JSON-field data change only). PR to `dev` open — **not merged**.
+
+### RBAC read path (confirmed tamper-proof)
+Authorization role is read from `app_metadata.role` (service-role-writable, not user-editable) in **both** trusted points, defaulting to least-privileged `customer` when absent:
+- `lib/auth/session.ts:40` — `getSessionUser()`: `const role = (user.app_metadata?.role as UserRole) || 'customer';`
+- `lib/supabase/middleware.ts:62`,69 — edge gate for `/operator/*` + `/admin/*`: `user?.app_metadata?.role` → `role || 'customer'`.
+
+`user_metadata` is never used for authz (explicit SECURITY comments at both sites). Old absent-role fallback was already `customer` — so a missing role could read public/customer surfaces but was already blocked from operator/admin by middleware.
+
+### What ran
+`scripts/backfill-roles.mjs` (idempotent, service-role admin API, `.env.local` path, same as `count-roles.mjs`) ran once against live. **Before === after** (nothing to fix):
+
+| Metric | Before | After |
+|---|---|---|
+| total users | 10 | 10 |
+| customer | 8 | 8 |
+| operator | 1 | 1 |
+| admin | 1 | 1 |
+| absent role | 0 | 0 |
+
+Result: **0 updated, 10 skipped.** Every user already had a role; operator + admin untouched. The pre-2026-06-09 risk was already satisfied on live data.
+
+### Durable artifacts (in repo)
+- `scripts/backfill-roles.mjs` — idempotent guard. Merges `app_metadata` (reads existing, adds `role` only, never drops/overwrites another key), sets `role='customer'` **only** where absent, never touches an existing role, safe to re-run. Prints total / updated / skipped + post-run breakdown.
+- `scripts/count-roles.mjs` — standalone read-only verifier.
+- Both write/read to whatever Supabase project the `SUPABASE_SERVICE_ROLE_KEY` belongs to — point at the correct env first. Service-role only, never client-exposed.
+
+### Remaining blocker before `dev → main` promotion
+**Registered office line on the footer** — intentionally omitted pending the founder's **Companies House AD01** filing (move registered office off the residential address). See §below ("Open compliance gap — registered office address"). Code path ready: uncomment the line in `components/layout/Footer.tsx` once AD01 is filed. Practical risk while open: ~zero.
 
 ---
 
@@ -325,7 +359,7 @@ Min 8 chars, 1 uppercase, 1 lowercase, 1 number, 1 special character. Enforced i
 ### Role source
 Authorization role reads from `app_metadata.role` (service-role-only) — not user-editable `user_metadata`. Fixed 2026-06-09.
 
-⚠️ Backfill required: any Supabase auth user created before 2026-06-09 has role only in `user_metadata` and will default to `customer`. Set `app_metadata.role` via the service-role admin API before operator onboarding.
+✅ **Backfill done (Task E, 2026-06-16).** Idempotent service-role script `scripts/backfill-roles.mjs` ran clean against live: **total 10, 0 with absent role, 0 updated, 10 skipped.** All users already carried `app_metadata.role` (8 customer / 1 operator / 1 admin) — operator/admin untouched. The script is the durable guard (merges `app_metadata`, sets `role='customer'` only where absent, never overwrites an existing role, safe to re-run). `scripts/count-roles.mjs` is the standalone read-only verifier. Point either at the correct project's `SUPABASE_SERVICE_ROLE_KEY` before running.
 
 ---
 
@@ -419,7 +453,7 @@ Next.js App Router UI
 |---|---|
 | `/public/logo.svg` + `/public/text-logo.svg` contain PilgrimCompare | **OPEN — fix before operator onboarding (Q1 scope)** |
 | PaymentEvidence RLS — operator/admin read access | **UNCONFIRMED** — storage policies updated (migration 006) but evidence-review UI and signed-download route not built. Resolve before Gate 2 fully closed. |
-| `app_metadata` role backfill | Pre-2026-06-09 users default to `customer`. Backfill via service-role admin API before onboarding operators. |
+| ~~`app_metadata` role backfill~~ | ✅ **CLOSED 2026-06-16 (Task E).** Live backfill ran clean: 10 users, 0 absent, 0 updated, 10 skipped; operator/admin untouched (8 customer / 1 operator / 1 admin). Durable idempotent guard `scripts/backfill-roles.mjs` in repo; verifier `scripts/count-roles.mjs`. |
 | Plausible analytics | Not wired — add `data-domain=pilgrimcompare.co.uk` in `app/layout.tsx` gated behind cookie consent. |
 
 ### P1 — high value, not launch-blocking today

--- a/scripts/backfill-roles.mjs
+++ b/scripts/backfill-roles.mjs
@@ -1,0 +1,98 @@
+/**
+ * One-off, IDEMPOTENT role backfill.
+ *
+ * Sets app_metadata.role = 'customer' ONLY for auth users that currently have
+ * NO role set. Users that already carry any role value (customer/operator/admin
+ * or anything else) are left exactly as-is.
+ *
+ * app_metadata is MERGED, never replaced: existing keys on each user are read
+ * and preserved; only `role` is added. No other app_metadata key is dropped or
+ * overwritten.
+ *
+ * Idempotent + safe to re-run: a second run finds 0 missing-role users and
+ * changes nothing.
+ *
+ * ENVIRONMENT: writes to whatever Supabase project the SUPABASE_SERVICE_ROLE_KEY
+ * in .env.local belongs to. Point it at the correct environment before running.
+ * Service-role only — never expose this key client-side.
+ *
+ * Run: node scripts/backfill-roles.mjs
+ * Verify independently with: node scripts/count-roles.mjs
+ */
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+
+config({ path: '.env.local' });
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !serviceKey) {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env.local');
+  process.exit(1);
+}
+
+const supabase = createClient(url, serviceKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// Page through every auth user.
+const all = [];
+let page = 1;
+const perPage = 1000;
+for (;;) {
+  const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
+  if (error) { console.error('listUsers error:', error.message); process.exit(1); }
+  all.push(...data.users);
+  if (data.users.length < perPage) break;
+  page++;
+}
+
+let updated = 0;
+let skipped = 0;
+for (const u of all) {
+  const role = u.app_metadata?.role;
+  const hasRole = !(role === undefined || role === null || role === '');
+  if (hasRole) {
+    skipped++;
+    continue;
+  }
+  // MERGE: preserve every existing app_metadata key, add role only.
+  const merged = { ...(u.app_metadata ?? {}), role: 'customer' };
+  const { error } = await supabase.auth.admin.updateUserById(u.id, {
+    app_metadata: merged,
+  });
+  if (error) {
+    console.error(`✗ ${u.email} (${u.id}): ${error.message}`);
+    continue;
+  }
+  console.log(`✓ backfilled role=customer  ${u.email}  ${u.id}`);
+  updated++;
+}
+
+// Post-run breakdown (re-derived from a fresh fetch so the numbers are real).
+const after = [];
+page = 1;
+for (;;) {
+  const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
+  if (error) { console.error('listUsers (post) error:', error.message); process.exit(1); }
+  after.push(...data.users);
+  if (data.users.length < perPage) break;
+  page++;
+}
+const byRole = new Map();
+let absent = 0;
+for (const u of after) {
+  const role = u.app_metadata?.role;
+  if (role === undefined || role === null || role === '') absent++;
+  else byRole.set(role, (byRole.get(role) ?? 0) + 1);
+}
+
+console.log('\n--- summary ---');
+console.log('total users:', all.length);
+console.log('updated:', updated);
+console.log('skipped (already had a role):', skipped);
+console.log('post-run role breakdown:');
+for (const [role, n] of [...byRole.entries()].sort()) {
+  console.log(`  ${role}: ${n}`);
+}
+console.log('post-run users with NO role:', absent);

--- a/scripts/count-roles.mjs
+++ b/scripts/count-roles.mjs
@@ -1,0 +1,49 @@
+/**
+ * READ-ONLY: count auth users by app_metadata.role. No writes.
+ * Run: node scripts/count-roles.mjs
+ */
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+
+config({ path: '.env.local' });
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !serviceKey) {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env.local');
+  process.exit(1);
+}
+
+const supabase = createClient(url, serviceKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const all = [];
+let page = 1;
+const perPage = 1000;
+for (;;) {
+  const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
+  if (error) { console.error('listUsers error:', error.message); process.exit(1); }
+  all.push(...data.users);
+  if (data.users.length < perPage) break;
+  page++;
+}
+
+const byRole = new Map();
+let absent = 0;
+for (const u of all) {
+  const role = u.app_metadata?.role;
+  if (role === undefined || role === null || role === '') {
+    absent++;
+  } else {
+    byRole.set(role, (byRole.get(role) ?? 0) + 1);
+  }
+}
+
+console.log('total users:', all.length);
+console.log('users WITH app_metadata.role set:');
+for (const [role, n] of [...byRole.entries()].sort()) {
+  console.log(`  ${role}: ${n}`);
+}
+console.log('distinct role values present:', [...byRole.keys()].sort().join(', ') || '(none)');
+console.log('users with NO app_metadata.role:', absent);


### PR DESCRIPTION
## What

Adds a durable, idempotent **role backfill** and a standalone **verifier**, and closes the §5/§8 P0 backfill item in `AI_NOTES.md`.

- `scripts/backfill-roles.mjs` — sets `app_metadata.role='customer'` **only** for auth users with no role set. **Merges** `app_metadata` (reads existing, adds `role` only — never drops/overwrites another key), **never touches** a user who already has any role value, **safe to re-run** (a second run finds 0 missing). Prints total / updated / skipped + post-run breakdown.
- `scripts/count-roles.mjs` — read-only role-count verifier.

Both use the service-role admin API via `.env.local` (same path as the existing migration scripts) and act on whatever Supabase project the `SUPABASE_SERVICE_ROLE_KEY` belongs to.

## RBAC read path (confirmed)

Role reads from `app_metadata.role` (tamper-proof, service-role-only) in both `lib/auth/session.ts:40` and `lib/supabase/middleware.ts:62`, defaulting to least-privileged `customer` when absent. `user_metadata` is never used for authz.

## Ran clean against live

| Metric | Before | After |
|---|---|---|
| total users | 10 | 10 |
| customer | 8 | 8 |
| operator | 1 | 1 |
| admin | 1 | 1 |
| absent role | 0 | 0 |

**0 updated, 10 skipped** — every user already had a role; operator + admin untouched. The script stays in-repo as the durable guard.

## Constraints honoured

- Service-role only, never client-exposed.
- No schema migration (JSON-field data change only).
- No payment-posture / "Not provided" / parked-flow changes. Only the two scripts + `AI_NOTES.md` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)