### PR TITLE
docs: record go-live promotion + post-deploy smoke results

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1,7 +1,22 @@
 # PilgrimCompare AI Handover — Single Source of Truth
 
-**Last verified:** 2026-06-16 (Task E — `app_metadata.role` backfill — idempotent script ran clean against live: total 10, 0 absent, 0 updated, 10 skipped, breakdown unchanged 8 customer / 1 operator / 1 admin). Task D (Plausible) wired + production-gated. **Both #89 (Task D) and #90 (Task E) merged to `dev`.** Task C (KT-→PC-) + Task 3 already on `dev`.
-**Branch:** `chore/app-metadata-role-backfill` — merged to `dev` (resolved AI_NOTES by keeping both §Task D + §Task E).
+## 🚀 GO-LIVE — `dev` promoted to `main` — 2026-06-16
+
+**Promoted `dev` → `main` via PR [#91](https://github.com/aliimrankhan86/kb-live/pull/91) (merge commit, no squash).**
+- **Final `main` HEAD:** `6aeace6` (merge commit) — includes the full `dev` tree at `230cbaf`.
+- CI green on the merge result; Vercel **production deploy green**.
+- **Post-deploy smoke check (live `pilgrimcompare.co.uk`, 2026-06-16):**
+  1. ✅ Site loads (200). Footer renders *"PilgrimCompare is a trading name of Paramount Consultants Limited, registered in England and Wales (company no. 09679002). VAT no. GB 221 6154 46"* — **NO registered office**, as intended.
+  2. ✅ Plausible live: cookieless `script.js` (200) + pageview `POST plausible.io/api/event` → **202 Accepted** (site ingests; a non-existent site would 404). *Realtime dashboard eyeball is founder's — needs Plausible login.*
+  3. ✅ Test enquiry completed to the PC- confirmation screen (**PC-DD26BB30**, on demo operator Al-Hidayah). Extra `/api/event` POST fired at confirmation with no navigation (the `'Enquiry Submitted'` goal) → 202. Three payment-posture lines present.
+- **Deferred (logged decisions, non-blocking):**
+  - **Registered office line** — intentionally omitted pending Companies House AD01 filing. Revisit on validation; path ready in `lib/legal.ts` (`registeredOffice`).
+  - **`KT-` sample string** in `scripts/test-emails.mjs:99,104,113` — cosmetic dev-utility literal only (not app/tests/e2e/generation). Cleanup whenever.
+
+---
+
+**Last verified:** 2026-06-16 (Task E — `app_metadata.role` backfill — idempotent script ran clean against live: total 10, 0 absent, 0 updated, 10 skipped, breakdown unchanged 8 customer / 1 operator / 1 admin). Task D (Plausible) wired + production-gated. **Both #89 (Task D) and #90 (Task E) merged to `dev`, then all of `dev` promoted to `main` (#91, HEAD `6aeace6`).** Task C (KT-→PC-) + Task 3 already on `dev`.
+**Branch:** `dev` promoted to `main` 2026-06-16. (`chore/app-metadata-role-backfill` was the last merge into `dev`, resolved AI_NOTES by keeping both §Task D + §Task E.)
 **Audience:** Claude, Codex, Kimi, and any AI/developer taking over the project.
 
 **Next immediate action:**

--- a/docs/DECISION-go-live-gate.md
+++ b/docs/DECISION-go-live-gate.md
@@ -1,0 +1,43 @@
+# Decision Record — Go-Live Gate (dev → main promotion)
+
+**Date:** 2026-06-16
+**Status:** Verified. Awaiting explicit founder go before merge. **No merge performed.**
+
+## The decision being protected
+
+1. **`chore/legal-entity-disclosure` branch stays closed/idle** until Companies House AD01 filing yields a virtual registered office address. No PR open. ✅
+2. **`tests/legal.test.ts` must NOT be tightened to require `registeredOffice`.** Promoting a guard that requires a field deliberately left blank would fail the build on `main`. ✅ Confirmed not staged anywhere.
+3. **`lib/legal.ts` `registeredOffice` is `''` on purpose** (pending AD01). Entity line renders with **no** registered office address. ✅
+
+## Verification (read-only, 2026-06-16)
+
+| Check | Result |
+|---|---|
+| dev HEAD | `230cbaf` |
+| main HEAD | `7431526` |
+| dev ahead of main | 21 commits |
+| `npx tsc --noEmit` | PASS |
+| `npm run build` | 0 errors |
+| Vitest | 1860/1860 (31 files) |
+| Working tree | clean on `dev`, matches `origin/dev` (only untracked `docs/THEME-KNOWLEDGE.md`, `screenshots/`) |
+| Open PRs | none |
+
+### Legal entity (matches decision)
+- `lib/legal.ts:9` — `registeredOffice: ''` with TODO comment. Not filled.
+- `tests/legal.test.ts` — guards only `companyName`, `companyNumber`, `contactEmail` non-empty. Does **not** require `registeredOffice`.
+- Render sites: `components/layout/Footer.tsx:258-263`, `app/terms/page.tsx:55-58`, `app/privacy/page.tsx:37-40`. None reference `registeredOffice`.
+- Rendered line: *"Paramount Consultants Limited, registered in England and Wales (company no. 09679002). VAT no. GB 221 6154 46"* — no office address.
+
+### Artifacts present on dev HEAD
+- **Plausible:** nonce'd cookieless script + `VERCEL_ENV === 'production'` gate (`app/layout.tsx:78-83`, `data-domain="pilgrimcompare.co.uk"`); `plausible.io` in **both** `script-src` (`middleware.ts:50`) and `connect-src` (`middleware.ts:55`); single `'Enquiry Submitted'` goal on PC- confirmation (`components/enquiry/EnquiryForm.tsx:86`).
+- **Role backfill:** `scripts/backfill-roles.mjs` + `scripts/count-roles.mjs`.
+- **Marketing opt-in + enquiry journey:** `app/api/enquiries/route.ts`, `app/packages/[slug]/enquire/page.tsx`, `components/enquiry/EnquiryForm.tsx` (`data-testid="enquiry-marketing-consent"`), `supabase/migrations/011_marketing_consents_table.sql`.
+
+### Minor non-blocker
+- `scripts/test-emails.mjs:99,104,113` still contain hardcoded sample `KT-9X2P4A` in a manual email-preview dev utility — not app code, tests, e2e, or a generation source. Task C's "zero KT- in code/tests/e2e/sql" still holds.
+
+### Founder prereqs (cannot be verified by tooling)
+- Plausible site `pilgrimcompare.co.uk` must exist in the dashboard, else launch runs blind from minute one.
+- `FEATURE_FEATURED_SLOTS=false` set in Vercel.
+
+Neither blocks the merge mechanically; do both before promoting.


### PR DESCRIPTION
Records the go-live promotion in AI_NOTES and adds the decision record.

- `dev` → `main` via #91 (merge commit). Final `main` HEAD `6aeace6`, includes dev tree `230cbaf`.
- Post-deploy smoke (live): footer entity line with no registered office; Plausible ingest 202; PC- enquiry confirmation fired 'Enquiry Submitted' goal.
- Deferred (logged): registered office line (AD01 pending); KT- sample literal in scripts/test-emails.mjs (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)