### PR TITLE
feat(analytics): swap Plausible for free Vercel Web Analytics

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -9,10 +9,27 @@
   1. ✅ Site loads (200). Footer renders *"PilgrimCompare is a trading name of Paramount Consultants Limited, registered in England and Wales (company no. 09679002). VAT no. GB 221 6154 46"* — **NO registered office**, as intended.
   2. ⚠️ Plausible **wiring** live: cookieless `script.js` (200) + pageview `POST plausible.io/api/event` → **202**. **CORRECTION:** 202 only proves the script posts correctly — Plausible returns 202 for *any* domain (registered or not) and silently drops events for domains not in an account. **It does NOT prove a site is recording.** Logged-out dashboard returned 404 (inconclusive alone — private dashboards 404 when logged out). **Founder cannot recall registering a Plausible account → analytics is most likely capturing nothing until the `pilgrimcompare.co.uk` site is created in a Plausible account.** Not a launch blocker / not a code bug — the wiring is correct and dormant; once the site is added, the already-live script populates immediately with no redeploy.
   3. ✅ Test enquiry completed to the PC- confirmation screen (**PC-DD26BB30**, on demo operator Al-Hidayah). Extra `/api/event` POST fired at confirmation with no navigation (the `'Enquiry Submitted'` goal) → 202 (same caveat as #2: fires + posts, capture depends on the site existing). Three payment-posture lines present.
+- **Analytics decision (RESOLVED 2026-06-16):** Plausible was never registered (no account, no Vercel integration, no env var — verified). Plausible Cloud is paid after trial; for a zero-cost POC we **swapped Plausible → Vercel Web Analytics** (free on Hobby, cookieless, same privacy story). See §Analytics swap below. **Founder action:** enable Web Analytics in the Vercel project → Analytics tab (free, no card) — script + events no-op until it's on.
 - **Deferred (logged decisions, non-blocking):**
-  - **⚠️ Plausible site registration (FOUNDER ACTION, OPEN)** — create `pilgrimcompare.co.uk` in a Plausible account, or analytics records nothing. Alternative: if Plausible is not wanted, remove the script + CSP entries + goal. Decide before relying on any analytics.
   - **Registered office line** — intentionally omitted pending Companies House AD01 filing. Revisit on validation; path ready in `lib/legal.ts` (`registeredOffice`).
   - **`KT-` sample string** in `scripts/test-emails.mjs:99,104,113` — cosmetic dev-utility literal only (not app/tests/e2e/generation). Cleanup whenever.
+
+---
+
+## §Analytics swap — Plausible → Vercel Web Analytics — 2026-06-16
+
+**Status: code complete on branch `feature/swap-plausible-vercel-analytics` (PR to `dev`). tsc clean, build 0 errors, Vitest 1860/1860.**
+
+**Why:** POC must cost nothing. Plausible Cloud is paid after a 30-day trial and was never actually registered (checked: no Plausible account recalled, no Vercel integration installed, no `PLAUSIBLE_*` env var, no self-hosted instance — the live 202s only proved the script posted; Plausible 202s any domain and drops unregistered ones). Vercel Web Analytics is free on the Hobby plan, cookieless, and same-origin — so the privacy/"no cookie consent" copy stays true.
+
+**What changed (supersedes §Task D — that Plausible wiring is now removed):**
+- `app/layout.tsx` — removed the `VERCEL_ENV`-gated Plausible `<script>`; added `<Analytics/>` from `@vercel/analytics/next`. No manual prod gate needed (auto-disabled outside production; preview/prod separated in the dashboard).
+- `middleware.ts` — removed `https://plausible.io` from **both** `script-src` and `connect-src`. Vercel's script + beacon are same-origin (`/_vercel/insights/*`), covered by `'self'` (a src'd same-origin script needs no nonce — nonces gate inline only). **CSP is now tighter than before.**
+- `components/enquiry/EnquiryForm.tsx` — `'Enquiry Submitted'` now fires via `track('Enquiry Submitted')` from `@vercel/analytics` (replaces `window.plausible?.(...)` + the `plausible` global type). Auto-no-ops outside production.
+- `app/privacy/page.tsx` + `components/compliance/CookieConsent.tsx` — tool name "Plausible" → "Vercel Web Analytics" (cookieless claim unchanged).
+- `package.json` — added `@vercel/analytics`.
+
+**Founder action (free, no card):** Vercel project → **Analytics** tab → **Enable Web Analytics**. Until enabled, `/_vercel/insights/script.js` 404s and events no-op — that's a dashboard toggle, not a code issue.
 
 ---
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import { JsonLdScript, graphJsonLd, organizationJsonLd, websiteJsonLd } from "@/
 import { Repository } from "@/lib/api/repository";
 import { isRfqQuoteEnabled } from "@/lib/config";
 import { ThemeProvider } from "@/components/theme/ThemeProvider";
+import { Analytics } from "@vercel/analytics/next";
 import { headers } from "next/headers";
 
 const inter = Inter({
@@ -67,22 +68,6 @@ export default async function RootLayout({
             __html: `(function(){try{var t=localStorage.getItem('theme');document.documentElement.setAttribute('data-theme',t==='light'?'light':'dark');}catch(e){}})();`,
           }}
         />
-        {/*
-          Plausible Cloud — cookieless pageview analytics (plain script.js build,
-          so the privacy/cookie copy stays true). Production-ONLY: Plausible
-          attributes hits to data-domain regardless of host, so rendering on
-          localhost or *.vercel.app previews would pollute the real stats.
-          data-domain is the stable brand domain, hardcoded — NOT derived from
-          NEXT_PUBLIC_SITE_URL (a placeholder locally).
-        */}
-        {process.env.VERCEL_ENV === "production" && (
-          <script
-            nonce={nonce}
-            defer
-            data-domain="pilgrimcompare.co.uk"
-            src="https://plausible.io/js/script.js"
-          />
-        )}
       </head>
       <body className="antialiased min-h-screen flex flex-col">
         <JsonLdScript data={siteJsonLd} />
@@ -100,6 +85,14 @@ export default async function RootLayout({
           <Footer cities={departureCities} rfqEnabled={rfqEnabled} />
           <CookieConsent />
         </ThemeProvider>
+        {/*
+          Vercel Web Analytics — cookieless, privacy-friendly (no consent banner
+          needed). Script + beacon are same-origin (/_vercel/insights/*), so the
+          strict CSP needs no external allowance: 'self' covers the src'd script
+          (nonces are only required for inline scripts). Auto-disabled outside
+          production; preview/prod are separated in the dashboard.
+        */}
+        <Analytics />
       </body>
     </html>
   );

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -74,7 +74,7 @@ export default function PrivacyPolicyPage() {
               evidence metadata, and communication notes.
             </li>
             <li>
-              <strong>Analytics data:</strong> anonymised page view data via Plausible
+              <strong>Analytics data:</strong> anonymised page view data via Vercel Web
               Analytics, which uses no cookies and stores no personal identifiers. See
               Section 8.
             </li>
@@ -208,10 +208,10 @@ export default function PrivacyPolicyPage() {
         <section className="mb-8">
           <h2 className="mb-3 text-xl font-semibold">8. Cookies and analytics</h2>
           <p className="mb-3 text-sm leading-relaxed">
-            <strong>Analytics:</strong> We use Plausible Analytics, a privacy-first service
+            <strong>Analytics:</strong> We use Vercel Web Analytics, a privacy-first service
             that collects no personal data and uses no cookies. It measures page views and
             aggregate traffic patterns only, with no cross-site tracking or personal
-            identifiers. No cookie consent is required for Plausible.
+            identifiers. No cookie consent is required for Vercel Web Analytics.
           </p>
           <p className="mb-3 text-sm leading-relaxed">
             <strong>Strictly necessary cookies:</strong> We use one session cookie for

--- a/components/compliance/CookieConsent.tsx
+++ b/components/compliance/CookieConsent.tsx
@@ -74,7 +74,7 @@ export function CookieConsent() {
             <p className="text-sm text-[var(--text)]">
               <strong className="block text-base mb-1">We value your privacy</strong>
               PilgrimCompare uses one essential cookie for authentication and session security.
-              We do not use analytics cookies — our analytics tool (Plausible) is cookieless.
+              We do not use analytics cookies — our analytics tool (Vercel Web Analytics) is cookieless.
               {' '}
               <Link
                 href="/privacy"

--- a/components/enquiry/EnquiryForm.tsx
+++ b/components/enquiry/EnquiryForm.tsx
@@ -4,15 +4,7 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { buttonVariants } from '@/components/ui/Button'
 import { PAYMENT_POSTURE_LINES } from '@/lib/content-rules'
-
-// Plausible Cloud goal (cookieless, anonymous). Optional-chained: the script
-// only loads in production (see app/layout.tsx), so this no-ops everywhere else.
-// This is the client-side conversion COUNT — not the Task 4 server-side lead log.
-declare global {
-  interface Window {
-    plausible?: (event: string, options?: { props?: Record<string, string | number | boolean> }) => void
-  }
-}
+import { track } from '@vercel/analytics'
 
 /**
  * Read-only summary of the package being enquired about. Pulled from the package
@@ -81,9 +73,11 @@ export function EnquiryForm({ summary, packageSlug }: EnquiryFormProps) {
         return
       }
       setReferenceCode(data.referenceCode)
-      // Fire the single 'Enquiry Submitted' Plausible goal exactly once, on the
-      // confirmed PC- enquiry. No-ops if the script isn't loaded (non-prod).
-      window.plausible?.('Enquiry Submitted')
+      // Fire the single 'Enquiry Submitted' Vercel Web Analytics custom event
+      // exactly once, on the confirmed PC- enquiry. Auto-no-ops outside
+      // production. This is the client-side conversion COUNT — not the Task 4
+      // server-side lead log.
+      track('Enquiry Submitted')
     } catch {
       setSubmit({ status: 'error', message: 'Network error. Please check your connection and try again.' })
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -44,15 +44,14 @@ function generateNonce(): string {
 
 function createContentSecurityPolicy(nonce: string): string {
   const isDev = process.env.NODE_ENV === 'development';
-  // Plausible Cloud: cookieless analytics. Script load needs script-src; the
-  // /api/event POST needs connect-src. Production-gated in the layout, but the
-  // CSP allowance is harmless in non-prod (no script renders to use it).
-  const scriptSrc = `script-src 'self' 'nonce-${nonce}' https://plausible.io${isDev ? " 'unsafe-eval'" : ''}`;
+  // Vercel Web Analytics serves its script and beacon same-origin
+  // (/_vercel/insights/*), so 'self' covers both script-src and connect-src —
+  // no external analytics domain is allowed.
+  const scriptSrc = `script-src 'self' 'nonce-${nonce}'${isDev ? " 'unsafe-eval'" : ''}`;
   const connectSrc = [
     "'self'",
     'https://*.supabase.co',
     'wss://*.supabase.co',
-    'https://plausible.io',
     ...(isDev ? ['ws://127.0.0.1:3000', 'ws://localhost:3000'] : []),
   ].join(' ');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/pg": "^8.20.0",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.38.0",
+        "@vercel/analytics": "^2.0.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.13",
         "lucide-react": "^1.18.0",
@@ -3871,6 +3872,48 @@
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/pg": "^8.20.0",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
+    "@vercel/analytics": "^2.0.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.13",
     "lucide-react": "^1.18.0",


### PR DESCRIPTION
Replaces paid Plausible Cloud with free Vercel Web Analytics for the POC (zero cost, cookieless, same privacy story).

## Changes
- `app/layout.tsx`: drop gated Plausible `<script>`, add `<Analytics/>` (same-origin beacon, auto-disabled outside production)
- `middleware.ts`: remove `https://plausible.io` from script-src + connect-src — CSP gets tighter (Vercel insights is `'self'`)
- `components/enquiry/EnquiryForm.tsx`: `'Enquiry Submitted'` now fires via `@vercel/analytics` `track()`
- `app/privacy/page.tsx` + `CookieConsent.tsx`: rename tool Plausible → Vercel Web Analytics (cookieless claim unchanged)
- `package.json`: add `@vercel/analytics`
- `AI_NOTES.md`: record the swap

## Verification
- tsc clean, `npm run build` 0 errors, Vitest 1860/1860
- Live CSP test runs on the Vercel preview for this PR

## Founder action (free, no card)
Vercel project → Analytics tab → Enable Web Analytics. Until enabled, the script 404s / events no-op (dashboard toggle, not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)