### PR TITLE
chore(c1): local/prod Supabase separation + stale-doc fix + prod cleanup guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,8 @@ backups/
 docs/01_STATUS.md
 docs/EXECUTION_QUEUE.md
 docs/_archive/
+
+# Local Supabase stack (C1 — LOCAL ONLY, not the prod project)
+supabase/config.toml
+supabase/.branches
+supabase/.temp

--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -502,16 +502,17 @@ Operators pay. Travellers are always free. Funds never flow through the platform
 ### Password rules
 Min 8 chars, 1 uppercase, 1 lowercase, 1 number, 1 special character. Enforced in `lib/validation.ts`, sign-up route, and `SignUpForm.tsx`.
 
-### Dev accounts (local `NODE_ENV=development` and `E2E_TESTING=1` only)
+### Local test accounts (real Supabase auth — not a code bypass)
 
-| Persona | Email | Password | Expected view |
+The old `@example.com` dev-login personas + the `/dev/login` route were **removed 2026-06-09 and no longer work**. Local sign-in now uses three real Supabase accounts, created by `node scripts/create-test-users.mjs`:
+
+| Persona | Email | Password | Role (`app_metadata`) |
 |---|---|---|---|
-| Customer | `customer@example.com` | `PilgrimCompare!2026` | Customer nav + public flows |
-| Operator verified | `operator@example.com` | `PilgrimCompare!2026` | Partner dashboard |
-| Operator new | `operator2@example.com` | `PilgrimCompare!2026` | Onboarding status flows |
-| Admin | `admin@example.com` | `PilgrimCompare!2026` | Admin audit flows |
+| Admin | `admin@test.local` | `TestPass1!` | admin |
+| Operator | `operator@test.local` | `TestPass1!` | operator |
+| Customer | `customer@test.local` | `TestPass1!` | customer |
 
-`PilgrimCompare!2026` is intentionally unchanged — it is a dev credential token, not user-facing copy.
+The script provisions these in whatever Supabase project `.env.local` points at. **LOCAL ONLY** once C1 (local/prod Supabase separation) lands — run it against the local stack, never prod. Roles live in `app_metadata` (the authz source), set at creation. `TestPass1!` is a dev credential token, not user-facing copy.
 
 ### Auth bypass paths
 - `__e2e_user` cookie: active only when `E2E_TESTING=1`. `next.config.ts` compiles `E2E_TESTING=''` in all deployments — path is dead in production/preview.

--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -1,5 +1,43 @@
 # PilgrimCompare AI Handover — Single Source of Truth
 
+## §C1 — Local/prod Supabase separation + branch hygiene + prod cleanup — 2026-07-07
+
+**Status: ✅ COMPLETE on branch `chore/c1-local-supabase`** (off `dev`). tsc clean · `npm run build` 0 errors · Vitest **1,869/1,869** · Playwright `--workers=1` **69 passed / 6 skipped / 0 failed** (parallel run shows the known multi-worker MockDB race on `bank-payment.spec.ts:15`; passes serially — same as CI). Autonomous session, gates 0–6.
+
+### What changed (this branch)
+- **Stale dev-login docs fixed** — the dead `@example.com` / `/dev/login` bypass (removed 2026-06-09) replaced with the real pattern in `CLAUDE.md` (gotcha) and `AI_NOTES.md` §5: three **real Supabase** accounts `admin@`/`operator@`/`customer@test.local`, password `TestPass1!`, roles in `app_metadata`, created by `node scripts/create-test-users.mjs`, **LOCAL ONLY** once C1 lands. `docs/NOW.md` got a correction banner (its `@example.com` rows are historical change-log, left verbatim).
+- **`.gitignore`** — added the local Supabase stack artefacts (`supabase/config.toml`, `supabase/.branches`, `supabase/.temp`). These describe the LOCAL Docker stack only, never the prod project.
+- **`scripts/remove-test-admin-guard.mjs`** (new) — Gate 4 Op 3, see below.
+
+### C1 local stack — how to reproduce (the reproducibility gap is closed)
+Docker running, Supabase CLI ≥2.109. RLS + storage-bucket SQL was **already fully captured** under `supabase/migrations/` — no prod `pg_dump` extraction was needed.
+1. `supabase init` (generates `supabase/config.toml` — gitignored).
+2. In `config.toml`: set `[db.migrations] enabled=false` and `[db.seed] enabled=false` — base tables come from Prisma, and `seed.sql` is demo data (standing rule forbids demo data). CLI auto-apply order is wrong (RLS migrations need tables first).
+3. `supabase start` → local API `http://127.0.0.1:54321`, DB `postgresql://postgres:postgres@127.0.0.1:54322/postgres`.
+4. Point `.env.local` at the local stack (URL, anon key, service_role key, `DATABASE_URL`, `DIRECT_URL` — all local CLI defaults). Keep `.env.production.local` as the prod snapshot.
+5. `npx prisma db push` (creates base tables from `prisma/schema.prisma`).
+6. Apply `supabase/migrations/*.sql` in numeric order via `npx prisma db execute --file <f>` (RLS, buckets, interests/enquiries/marketing tables — idempotent). Skip the gitignored macOS dup `012… 2.sql`.
+7. `node scripts/create-test-users.mjs` (creates the three `*.test.local` accounts in the LOCAL stack).
+
+**Verified local:** 15 public tables, RLS on across all key tables, 4 storage buckets (`evidence-files`, `operator-exports`, `package-images`, `payment-evidence`), **zero rows** in users/packages/operator_profiles. App boots; `admin@test.local`/`TestPass1!` logs in; `/api/auth/me` → role `admin`. Project ref local (`supabase-demo`/`127.0.0.1`) vs prod (`nzvepuzzxjoxvpcrlozx`). **Local dev cannot touch prod data.**
+
+### Gate 4 — three authorised prod operations (executed via `.env.production.local`)
+1. **Role mirror sync** — `public.users.role` for `aliimrankhan86@gmail.com`: `customer` → **`admin`** (idempotent; `app_metadata.role` was already `admin`). Authz still reads `app_metadata`; this only fixes the mirror.
+2. **Test-account cleanup** — `operator@test.local` + `customer@test.local` had **0 FK references** (checked every FK into `public.users`) and **no `public.users` mirror rows** → deleted from prod `auth.users` (both gone; admin API 200). `admin@test.local` **preserved**.
+3. **`scripts/remove-test-admin-guard.mjs`** — dry-run by default, `--execute` to act; deletes `admin@test.local` (auth + mirror). Refuses to remove the **last** admin (lockout guard, reads `app_metadata.role`). Targets `.env.production.local` if present. Dry-run validated against prod (sees `aliimrankhan86@gmail.com` as the other admin). **For the founder to run after verifying gmail admin login on live.**
+
+### Branch hygiene (Gate 1)
+main untouched. dev = main minus promotion-merge commits (healthy). **PR #104 merged docs-only into dev + branch deleted.** Deleted 26 merged local + 6 merged remote branches. Stragglers kept (unmerged): local `feature/mobile-ux-pass-sliders-footer`, `fix/duplicate-email-error`, `fix/merge-main-conflicts`, `fix/signup-and-auth-confirm`, `qa/app-readiness-audit`; remote `origin/ci/add-pr-workflow`.
+
+### Open risks / waiting on founder
+- **`admin@test.local` still on prod (deliberate).** Founder: (1) log in fresh on live as `aliimrankhan86@gmail.com`, confirm admin; (2) run `node scripts/remove-test-admin-guard.mjs --execute`; (3) review dev before promoting.
+- `config.toml` is gitignored per the C1 brief — a fresh clone reproduces the local stack via the steps above (each dev runs `supabase init` + provisioning).
+
+### Next immediate action
+**C2 — register-interest capture** (pending founder-approved copy). Do not start until copy is approved.
+
+---
+
 ## 🚀 GO-LIVE — `dev` promoted to `main` — 2026-06-16
 
 **Current `main` HEAD: `e156378`** (3rd promotion, PR [#99](https://github.com/aliimrankhan86/kb-live/pull/99), merge commit, no squash) — **docs + dev-utility only, zero app runtime change vs `823f860`.** Brings live: #96 (record 2nd promotion), #97 (`docs/ANALYTICS.md`), #98 (cleanup — verified Vercel-analytics copy in `app/privacy/page.tsx` + `components/compliance/CookieConsent.tsx`, swapped dev-utility `KT-9X2P4A` → `PC-7F3A9C21` in `scripts/test-emails.mjs`). Pre-flight on dev `06db208`: tsc clean, build 0 errors (66/66), Vitest **1,860/1,860**, zero `KT-` in code/tests/e2e/sql.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ When a local problem turns out to be **expected behavior, not a bug**, capture i
 
 ## Known gotchas (read before debugging "broken" local behavior)
 
-- **Dev login fails locally → check the server, not the code.** Dev personas (`customer@example.com` / `operator@example.com` / `operator2@example.com` / `admin@example.com`, all `PilgrimCompare!2026`) only work under `npm run dev` (`NODE_ENV=development`). A local prod build (`npm run build` + `npm start` → `next start`) runs `NODE_ENV=production`, so `isDevAuthEnabled()` is false and sign-in returns `401 AUTH_INVALID_CREDENTIALS` **by design**. Fix = restart with `npm run dev`. Full note: `PROJECT_BRIEF.md` §5, `AI_NOTES.md` §4.
+- **Local login uses real Supabase test accounts — not a code bypass.** The old `@example.com` dev-login personas and the `/dev/login` route were **removed 2026-06-09 and no longer work** (do not reintroduce them). Local sign-in now uses three real Supabase auth accounts — `admin@test.local`, `operator@test.local`, `customer@test.local`, all password `TestPass1!` — created by `node scripts/create-test-users.mjs`. The script provisions them in whatever Supabase project `.env.local` points at; **LOCAL ONLY** once C1 (local/prod Supabase separation) lands, so run it against the local stack, never prod. Roles are set in `app_metadata` (the authz source). If local login fails, the accounts are missing → run the script. Full note: `AI_NOTES.md` §5.
 
 ## Execution rules (mandatory every session)
 

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -11,6 +11,8 @@
 - **Current source-of-truth note:** Prompt 6 verified 2026-06-12. Full detail in `AI_NOTES.md` §23.
 - **Canonical handover:** `AI_NOTES.md` is the single source of truth for verified status, implementation posture, and pending areas.
 
+> ⚠️ **Local login correction (2026-07-07).** The `@example.com` dev-login personas and the `/dev/login` route referenced in the historical change-log entries below were **removed 2026-06-09 and no longer work**. Local sign-in now uses three real Supabase accounts — `admin@test.local` / `operator@test.local` / `customer@test.local`, all password `TestPass1!` — created by `node scripts/create-test-users.mjs`. **LOCAL ONLY** once C1 (local/prod Supabase separation) lands: run the script against the local stack, never prod. Roles live in `app_metadata`. Canonical: `AI_NOTES.md` §5. The dated rows below are kept verbatim as historical record — do not treat their `@example.com` credentials as current.
+
 ## What works (verified)
 
 - **Tests**: `npm run test` passes (24 files, 1,818/1,818 tests) — verified 2026-06-12.

--- a/reports/2026-07-07-c1-autonomous-session.md
+++ b/reports/2026-07-07-c1-autonomous-session.md
@@ -1,0 +1,99 @@
+# C1 Autonomous Session — 2026-07-07
+
+Local/prod Supabase separation, branch hygiene, stale-doc cleanup, authorised prod
+cleanup, tests, and merge to dev. Run without merging or pushing to `main`, and without
+deploying. All work landed on `chore/c1-local-supabase` → PR **#105** to `dev`.
+
+---
+
+## Branch state — before and after
+
+**Before**
+- `origin/main` `8f58818` · `origin/dev` `99909c2` · working branch `docs/record-preclean` `5c395bb` (= PR #104).
+- One open PR: **#104** (docs-only), from `docs/record-preclean` → `dev`.
+- ~30 stale local branches, plus stale remote branches; several remotes already pruned on fetch.
+
+**After**
+- `origin/main` **untouched** (`8f58818`).
+- `origin/dev` = `02af94a` (PR #104 merged) → will advance again when PR #105 merges.
+- Open PR: **#105** (`chore/c1-local-supabase` → `dev`).
+- Deleted **26 merged local** + **6 merged remote** branches.
+- Remaining remote branches: `origin/dev`, `origin/main`, `origin/ci/add-pr-workflow` (last is unmerged — kept).
+- Unmerged local stragglers kept: `feature/mobile-ux-pass-sliders-footer`, `fix/duplicate-email-error`, `fix/merge-main-conflicts`, `fix/signup-and-auth-confirm`, `qa/app-readiness-audit`.
+
+## What merged
+- **PR #104** (docs-only: `.gitignore`, `AI_NOTES.md`, `STATUS.md`) → `dev` as merge commit `02af94a`. Verified the net diff was exactly those 3 files; CI was green; branch deleted.
+- **PR #105** (this session's C1 branch) → opened to `dev`; merged once CI green (see Test results). `main` never touched.
+
+`main` vs `dev`: the only commits on `main` not on `dev` are the 7 promotion merge commits (`Merge pull request #NN from …/dev`) — the expected, healthy promotion delta. No genuine non-promotion commits, so `main` was **not** merged into `dev`.
+
+## C1 outcome (local/prod Supabase separation)
+Local Supabase stack stood up with the CLI (Docker running). RLS policies and storage-bucket
+SQL were **already fully captured** as files under `supabase/migrations/` (`001_enable_rls`,
+`002`–`004` buckets, `005`/`006`/`008`/`009` policies) — so **no read-only `pg_dump` from prod
+was required**; the reproducibility gap was already closed on the file side and is now exercised
+end-to-end.
+
+Reproducible provisioning sequence (documented in `AI_NOTES.md §C1`):
+`supabase init` → disable `[db.migrations]` + `[db.seed]` in the (gitignored) `config.toml`
+→ `supabase start` → repoint `.env.local` at the local stack → `prisma db push` →
+apply `supabase/migrations/*.sql` in numeric order → `node scripts/create-test-users.mjs`.
+
+**Verified local:** 15 public tables; RLS on across all key tables; 4 storage buckets
+(`evidence-files`, `operator-exports`, `package-images`, `payment-evidence`); **zero rows** in
+`users`/`packages`/`operator_profiles`. App boots on `127.0.0.1:3000`; `admin@test.local` /
+`TestPass1!` signs in; `/api/auth/me` returns role `admin`. Local project ref
+(`supabase-demo` / `127.0.0.1:54322`) is provably distinct from prod
+(`nzvepuzzxjoxvpcrlozx`). **Acceptance met: local dev cannot touch prod data.**
+
+Local-stack artefacts (`supabase/config.toml`, `supabase/.branches`, `supabase/.temp`) are
+gitignored per the brief; `.env.local` now points local; `.env.production.local` holds the
+prod snapshot for Gate 4.
+
+## The three prod operations (before → after)
+Executed against prod (`nzvepuzzxjoxvpcrlozx`) via `.env.production.local`. Read-only
+inspection first, then writes.
+
+1. **Role mirror sync — `aliimrankhan86@gmail.com`.**
+   Before: `public.users.role = customer` (while `app_metadata.role` was already `admin`).
+   After: `public.users.role = admin`. Idempotent; authz reads `app_metadata`, so this only
+   fixes the mirror.
+
+2. **Delete `operator@test.local` + `customer@test.local`.**
+   Before: both present in `auth.users`; checked every FK into `public.users`
+   (`operator_profiles`, `payment_details`, `bank_change_requests` ×3, `audit_log_entries`,
+   `quote_requests`, `booking_intents`, `complaints`) → **0 references each**; **0**
+   `public.users` mirror rows. After: both deleted from `auth.users` (admin API), 0 rows
+   remaining. `admin@test.local` confirmed **preserved**.
+
+3. **`scripts/remove-test-admin-guard.mjs` (written, not executed against `admin@test.local`).**
+   Dry-run by default, `--execute` to act. Removes `admin@test.local` (auth + mirror) but
+   **refuses to remove the last admin** (lockout guard on `app_metadata.role`). Targets
+   `.env.production.local` if present. Dry-run validated against prod — it correctly sees
+   `aliimrankhan86@gmail.com` as the other admin and reports it would delete `admin@test.local`
+   (1 auth row, 0 mirror rows) without making changes.
+
+No other prod writes occurred.
+
+## Test results
+- `npx tsc --noEmit` — clean.
+- `npm run build` — 0 errors.
+- `npm run test` (Vitest) — **1,869 / 1,869** passed (32 files).
+- `npx playwright test` — parallel run showed **1 failure** on
+  `bank-payment.spec.ts:15` (firefox), the AI_NOTES-documented multi-worker MockDB race
+  between the operator/bank-payment specs. Re-run under CI conditions
+  (`--workers=1`): **69 passed / 6 skipped / 0 failed**. Playwright uses `E2E_TESTING=1` +
+  MockDB and never touches prod.
+
+## Blockers
+None hit. (Prior sessions reported a sandboxed environment; this session had full tool
+access — Node, Docker, Supabase CLI, network — so all gates executed for real.)
+
+## Waiting on the founder (three items, in order)
+1. **Verify gmail admin login on live** — sign in fresh at the live site as
+   `aliimrankhan86@gmail.com` and confirm admin access (role is in `app_metadata`; log in
+   fresh so the JWT carries it).
+2. **Run `node scripts/remove-test-admin-guard.mjs --execute`** — only after step 1, to remove
+   the synthetic `admin@test.local` from prod. (Dry-run first if you want to preview.)
+3. **Review `dev`** (with PR #105 merged) before promoting `dev → main`. Promotion remains a
+   human-gated step; nothing in this session touched `main` or deployed.

--- a/scripts/remove-test-admin-guard.mjs
+++ b/scripts/remove-test-admin-guard.mjs
@@ -1,0 +1,117 @@
+/**
+ * Remove the synthetic admin@test.local account from PRODUCTION (auth + mirror).
+ *
+ * WHY THIS IS A SEPARATE, GUARDED SCRIPT
+ * admin@test.local was the ONLY admin on prod for a long time. It is the
+ * break-glass admin and must NOT be deleted until a real admin (a gmail
+ * account) can log in. This script is intentionally dry-run by default and
+ * refuses to remove the last admin, so it cannot lock you out.
+ *
+ * USAGE
+ *   node scripts/remove-test-admin-guard.mjs             # DRY-RUN (default) — shows what would happen, no writes
+ *   node scripts/remove-test-admin-guard.mjs --execute   # actually delete admin@test.local
+ *
+ * PRECONDITIONS (do these first)
+ *   1. Verify you can log in to the LIVE site as aliimrankhan86@gmail.com and
+ *      that it has admin access (role lives in app_metadata; log in fresh so
+ *      the JWT carries the admin role).
+ *   2. Only then run this with --execute.
+ *
+ * TARGET: this script uses .env.production.local if present (the prod creds),
+ * otherwise .env.local. It prints the target project and whether it is prod.
+ *
+ * Modelled on scripts/create-test-users.mjs (env loading + service-role admin
+ * client) and scripts/backfill-roles.mjs (app_metadata role reads).
+ */
+
+import { existsSync } from 'node:fs';
+import { config } from 'dotenv';
+import pg from 'pg';
+import { createClient } from '@supabase/supabase-js';
+
+const ENV_FILE = existsSync('.env.production.local') ? '.env.production.local' : '.env.local';
+config({ path: ENV_FILE });
+
+const TARGET_EMAIL = 'admin@test.local';
+const EXPECTED_PROD_REF = 'nzvepuzzxjoxvpcrlozx';
+const EXECUTE = process.argv.includes('--execute');
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const directUrl = process.env.DIRECT_URL;
+
+if (!url || !serviceKey || !directUrl) {
+  console.error(`Missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY / DIRECT_URL in ${ENV_FILE}`);
+  process.exit(1);
+}
+
+const isProd = url.includes(EXPECTED_PROD_REF);
+
+console.log('─'.repeat(64));
+console.log(`env file       : ${ENV_FILE}`);
+console.log(`target project : ${url}  (${isProd ? 'PROD' : 'NON-PROD'})`);
+console.log(`target account : ${TARGET_EMAIL}`);
+console.log(`mode           : ${EXECUTE ? '⚠️  EXECUTE (will delete)' : 'DRY-RUN (default, no writes)'}`);
+console.log('─'.repeat(64));
+
+const client = new pg.Client({ connectionString: directUrl });
+await client.connect();
+const q = async (sql, params = []) => (await client.query(sql, params)).rows;
+
+try {
+  // --- LOCKOUT GUARD: never remove the last admin --------------------------
+  // Authorization role is app_metadata.role (the authz source of truth).
+  const otherAdmins = await q(
+    `select email from auth.users
+       where raw_app_meta_data->>'role' = 'admin' and email <> $1
+       order by email`,
+    [TARGET_EMAIL]
+  );
+  console.log(`Other admins (app_metadata.role='admin'): ${otherAdmins.length}`);
+  otherAdmins.forEach((r) => console.log(`   • ${r.email}`));
+  if (otherAdmins.length === 0) {
+    console.error(
+      `\n✋ ABORT — ${TARGET_EMAIL} appears to be the only admin. Promote a real\n` +
+      `   admin (e.g. a gmail account) and confirm you can log in as it BEFORE\n` +
+      `   removing this account. Nothing was changed.`
+    );
+    process.exit(2);
+  }
+
+  // --- Resolve the target ---------------------------------------------------
+  const authRow = await q(`select id, email from auth.users where email = $1`, [TARGET_EMAIL]);
+  if (authRow.length === 0) {
+    console.log(`\n✓ ${TARGET_EMAIL} is not present in auth.users — nothing to do.`);
+    process.exit(0);
+  }
+  const id = authRow[0].id;
+  const mirror = await q(`select id from public.users where id = $1`, [id]);
+  console.log(`\nWould delete:`);
+  console.log(`   auth.users     : 1 row (id=${id})`);
+  console.log(`   public.users   : ${mirror.length} mirror row(s)`);
+
+  if (!EXECUTE) {
+    console.log(`\nDRY-RUN — no changes made. Re-run with --execute to delete.`);
+    process.exit(0);
+  }
+
+  // --- EXECUTE --------------------------------------------------------------
+  if (mirror.length > 0) {
+    await q(`delete from public.users where id = $1`, [id]);
+    console.log(`   deleted public.users mirror row`);
+  }
+  const admin = createClient(url, serviceKey, { auth: { autoRefreshToken: false, persistSession: false } });
+  const { error } = await admin.auth.admin.deleteUser(id);
+  if (error) {
+    console.error(`   ✋ auth deletion failed: ${error.message}`);
+    process.exit(3);
+  }
+  console.log(`   deleted auth.users row`);
+
+  const goneAuth = await q(`select count(*)::int n from auth.users where id = $1`, [id]);
+  const goneMirror = await q(`select count(*)::int n from public.users where id = $1`, [id]);
+  console.log(`\nAFTER: auth.users rows=${goneAuth[0].n}, public.users rows=${goneMirror[0].n}`);
+  console.log(goneAuth[0].n === 0 ? `✓ ${TARGET_EMAIL} removed.` : `⚠️ still present — check manually.`);
+} finally {
+  await client.end();
+}


### PR DESCRIPTION
## C1 — local/prod Supabase separation (autonomous session, gates 0–6)

**Branch-only changes (no app runtime touched):** docs, `.gitignore`, one new script.

- **Gate 2 — stale-doc fix:** replace the dead `@example.com` / `/dev/login` bypass with the real `*.test.local` + `create-test-users.mjs` pattern in `CLAUDE.md` + `AI_NOTES.md §5`; correction banner in `docs/NOW.md` (history preserved).
- **Gate 3 — C1:** local Supabase stack stood up (`supabase init/start`), schema via `prisma db push` + existing `supabase/migrations/*.sql` (RLS + buckets already file-captured — no prod extraction needed). `.env.local` repointed local; test users created local. Verified: app boots, `admin@test.local` logs in, `/api/auth/me` role admin, **zero prod rows**. Local artefacts gitignored.
- **Gate 4 — prod (done, logged):** synced `public.users.role` for `aliimrankhan86@gmail.com` → admin; deleted `operator@`/`customer@test.local` (0 FK refs); added `scripts/remove-test-admin-guard.mjs` (dry-run default, lockout-guarded) for the founder to remove `admin@test.local` after verifying gmail admin login.

**Gates:** tsc clean · build 0 errors · Vitest 1869/1869 · Playwright `--workers=1` 69 passed / 6 skipped / 0 failed.

Full detail: `AI_NOTES.md §C1` and `reports/2026-07-07-c1-autonomous-session.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)