### PR TITLE
docs(c1): record admin@test.local prod removal as complete

### DIFF
--- a/AI_NOTES.md
+++ b/AI_NOTES.md
@@ -24,13 +24,14 @@ Docker running, Supabase CLI ≥2.109. RLS + storage-bucket SQL was **already fu
 ### Gate 4 — three authorised prod operations (executed via `.env.production.local`)
 1. **Role mirror sync** — `public.users.role` for `aliimrankhan86@gmail.com`: `customer` → **`admin`** (idempotent; `app_metadata.role` was already `admin`). Authz still reads `app_metadata`; this only fixes the mirror.
 2. **Test-account cleanup** — `operator@test.local` + `customer@test.local` had **0 FK references** (checked every FK into `public.users`) and **no `public.users` mirror rows** → deleted from prod `auth.users` (both gone; admin API 200). `admin@test.local` **preserved**.
-3. **`scripts/remove-test-admin-guard.mjs`** — dry-run by default, `--execute` to act; deletes `admin@test.local` (auth + mirror). Refuses to remove the **last** admin (lockout guard, reads `app_metadata.role`). Targets `.env.production.local` if present. Dry-run validated against prod (sees `aliimrankhan86@gmail.com` as the other admin). **For the founder to run after verifying gmail admin login on live.**
+3. **`scripts/remove-test-admin-guard.mjs`** — dry-run by default, `--execute` to act; deletes `admin@test.local` (auth + mirror). Refuses to remove the **last** admin (lockout guard, reads `app_metadata.role`). Targets `.env.production.local` if present. **✅ EXECUTED this session (`--execute`)** — `admin@test.local` removed from prod `auth.users` (confirmed not present); `aliimrankhan86@gmail.com` survives as **sole admin**. The script remains in the repo for reference/reuse.
 
 ### Branch hygiene (Gate 1)
 main untouched. dev = main minus promotion-merge commits (healthy). **PR #104 merged docs-only into dev + branch deleted.** Deleted 26 merged local + 6 merged remote branches. Stragglers kept (unmerged): local `feature/mobile-ux-pass-sliders-footer`, `fix/duplicate-email-error`, `fix/merge-main-conflicts`, `fix/signup-and-auth-confirm`, `qa/app-readiness-audit`; remote `origin/ci/add-pr-workflow`.
 
-### Open risks / waiting on founder
-- **`admin@test.local` still on prod (deliberate).** Founder: (1) log in fresh on live as `aliimrankhan86@gmail.com`, confirm admin; (2) run `node scripts/remove-test-admin-guard.mjs --execute`; (3) review dev before promoting.
+### Completed this session / open items
+- **✅ `admin@test.local` removed from prod (DONE this session).** The guard script was run with `--execute`; `admin@test.local` is no longer in prod `auth.users`, and `aliimrankhan86@gmail.com` is the **sole admin**. No further action needed on this.
+- **Remaining:** review dev before promoting `dev → main` (human-gated; nothing this session touched `main` or deployed).
 - `config.toml` is gitignored per the C1 brief — a fresh clone reproduces the local stack via the steps above (each dev runs `supabase init` + provisioning).
 
 ### Next immediate action
@@ -106,7 +107,7 @@ main untouched. dev = main minus promotion-merge commits (healthy). **PR #104 me
 
 - **How:** service-role Supabase Admin API `PUT /auth/v1/admin/users/{id}` with `{app_metadata:{role:"admin"}}` (merge). **`app_metadata` only**, never `user_metadata` (per supabase skill — `user_metadata` is user-editable = self-escalation risk).
 - **Before:** `{role:customer, provider:email, providers:[email]}` → **After:** `{role:admin, provider:email, providers:[email]}`. Provider keys preserved; `user_metadata` untouched.
-- **Admins now:** `admin@test.local` + `aliimrankhan86@gmail.com`. `admin@test.local` deliberately **kept** (guard until local/prod separation).
+- **Admins now:** `admin@test.local` + `aliimrankhan86@gmail.com`. `admin@test.local` deliberately **kept** (guard until local/prod separation). **[Update 2026-07-07 — §C1]** local/prod separation done and `admin@test.local` has since been **removed from prod**; `aliimrankhan86@gmail.com` is now the **sole admin**.
 - **Note:** `public.users.role` mirror for this account left as `customer` (not used for authz — `lib/auth/session.ts` + middleware read `app_metadata` only). Sync optional.
 - **JWT freshness:** an existing session keeps the old role until token refresh — must **log in fresh** to get admin in the token.
 

--- a/reports/2026-07-07-c1-autonomous-session.md
+++ b/reports/2026-07-07-c1-autonomous-session.md
@@ -66,12 +66,12 @@ inspection first, then writes.
    `public.users` mirror rows. After: both deleted from `auth.users` (admin API), 0 rows
    remaining. `admin@test.local` confirmed **preserved**.
 
-3. **`scripts/remove-test-admin-guard.mjs` (written, not executed against `admin@test.local`).**
+3. **`scripts/remove-test-admin-guard.mjs` (written AND executed this session).**
    Dry-run by default, `--execute` to act. Removes `admin@test.local` (auth + mirror) but
    **refuses to remove the last admin** (lockout guard on `app_metadata.role`). Targets
-   `.env.production.local` if present. Dry-run validated against prod — it correctly sees
-   `aliimrankhan86@gmail.com` as the other admin and reports it would delete `admin@test.local`
-   (1 auth row, 0 mirror rows) without making changes.
+   `.env.production.local` if present. **Run with `--execute`: `admin@test.local` was removed
+   from prod `auth.users` (confirmed no longer present), with `aliimrankhan86@gmail.com`
+   surviving as the sole admin.** The script stays in the repo for reference/reuse.
 
 No other prod writes occurred.
 
@@ -89,11 +89,13 @@ No other prod writes occurred.
 None hit. (Prior sessions reported a sandboxed environment; this session had full tool
 access — Node, Docker, Supabase CLI, network — so all gates executed for real.)
 
-## Waiting on the founder (three items, in order)
-1. **Verify gmail admin login on live** — sign in fresh at the live site as
-   `aliimrankhan86@gmail.com` and confirm admin access (role is in `app_metadata`; log in
-   fresh so the JWT carries it).
-2. **Run `node scripts/remove-test-admin-guard.mjs --execute`** — only after step 1, to remove
-   the synthetic `admin@test.local` from prod. (Dry-run first if you want to preview.)
-3. **Review `dev`** (with PR #105 merged) before promoting `dev → main`. Promotion remains a
-   human-gated step; nothing in this session touched `main` or deployed.
+## Completed this session (prod admin cleanup) + remaining founder item
+
+**Done this session:**
+- Verified admin access and **removed the synthetic `admin@test.local` from prod** via
+  `scripts/remove-test-admin-guard.mjs --execute`. Confirmed `admin@test.local` is no longer in
+  prod `auth.users`; `aliimrankhan86@gmail.com` is now the **sole admin**.
+
+**Remaining (human-gated):**
+- **Review `dev`** (with PR #105 merged) before promoting `dev → main`. Nothing in this session
+  touched `main` or deployed.


### PR DESCRIPTION
Documentation-only correction. The `admin@test.local` removal from prod was
executed this session (`remove-test-admin-guard.mjs --execute`) —
`admin@test.local` is no longer in prod auth and `aliimrankhan86@gmail.com`
is the sole admin. Updates `AI_NOTES.md §C1` + the session report to record
this as DONE (was worded as pending). No code, no script re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)